### PR TITLE
feat: タイムラインに画像サムネイル表示とプレビューダイアログを追加

### DIFF
--- a/src/main/timeline.ts
+++ b/src/main/timeline.ts
@@ -34,5 +34,14 @@ export async function fetchTimeline(
       displayName: status.account.displayName,
       avatarUrl: status.account.avatar,
     },
+    mediaAttachments: status.mediaAttachments
+      .filter((m) => m.url != null && m.previewUrl != null)
+      .map((m) => ({
+        id: m.id,
+        type: m.type,
+        url: m.url!,
+        previewUrl: m.previewUrl!,
+        description: m.description ?? null,
+      })),
   }));
 }

--- a/src/renderer/components/MediaGallery.tsx
+++ b/src/renderer/components/MediaGallery.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Modal } from 'antd';
+import styled from 'styled-components';
+import type { PostMediaAttachment } from '../../shared/types.ts';
+
+interface MediaGalleryProps {
+  attachments: PostMediaAttachment[];
+}
+
+const Grid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+`;
+
+const Thumbnail = styled.img`
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 4px;
+  cursor: pointer;
+  display: block;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;
+
+const PreviewImage = styled.img`
+  width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+`;
+
+export function MediaGallery({ attachments }: MediaGalleryProps): React.JSX.Element | null {
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+
+  const images = attachments.filter((a) => a.type === 'image');
+  if (images.length === 0) return null;
+
+  const previewImage = previewIndex !== null ? images[previewIndex] : null;
+
+  return (
+    <>
+      <Grid>
+        {images.map((image, index) => (
+          <Thumbnail
+            key={image.id}
+            src={image.previewUrl}
+            alt={image.description ?? ''}
+            onClick={() => setPreviewIndex(index)}
+          />
+        ))}
+      </Grid>
+      <Modal
+        open={previewImage !== null}
+        onCancel={() => setPreviewIndex(null)}
+        footer={null}
+        centered
+        width="auto"
+        styles={{ body: { padding: 0, lineHeight: 0 } }}
+      >
+        {previewImage && (
+          <PreviewImage src={previewImage.url} alt={previewImage.description ?? ''} />
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -1,6 +1,7 @@
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import type { Post } from '../../shared/types.ts';
+import { MediaGallery } from './MediaGallery.tsx';
 
 interface PostItemProps {
   post: Post;
@@ -124,6 +125,7 @@ export function PostItem({ post }: PostItemProps): React.JSX.Element {
           <DisplayName>{post.account.displayName}</DisplayName>
         </HeaderLine>
         <PostBody dangerouslySetInnerHTML={{ __html: sanitizeContent(post.content) }} />
+        {post.mediaAttachments.length > 0 && <MediaGallery attachments={post.mediaAttachments} />}
         {post.url ? (
           <Timestamp href={post.url} onClick={handleTimestampClick}>
             {formatTimestamp(post.createdAt)}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,6 +33,21 @@ export interface OAuthExchangeTokenParams {
 /** Timeline type */
 export type TimelineType = 'home' | 'public' | 'favourites';
 
+/** Media attachment type */
+export type MediaAttachmentType = 'image' | 'video' | 'gifv' | 'audio' | 'unknown';
+
+/** A media attachment on a post */
+export interface PostMediaAttachment {
+  id: string;
+  type: MediaAttachmentType;
+  /** Full-size URL */
+  url: string;
+  /** Scaled-down preview URL */
+  previewUrl: string;
+  /** Alt text */
+  description: string | null;
+}
+
 /** A post (status) to render in the timeline */
 export interface Post {
   id: string;
@@ -47,6 +62,8 @@ export interface Post {
     displayName: string;
     avatarUrl: string;
   };
+  /** Media attachments (images, videos, etc.) */
+  mediaAttachments: PostMediaAttachment[];
 }
 
 /** Parameters for fetching a timeline */


### PR DESCRIPTION
close #10 

## Summary
- タイムラインの投稿に画像サムネイルをグリッド表示する `MediaGallery` コンポーネントを追加
- サムネイルクリックでフルサイズ画像をモーダルプレビュー表示
- `PostMediaAttachment` 型を定義し、メインプロセスで Mastodon API のメディア添付データをマッピング

## Test plan
- [x] 画像付き投稿でサムネイルが表示されることを確認
- [x] サムネイルクリックでプレビューモーダルが開くことを確認
- [x] 画像なしの投稿ではギャラリーが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)