### PR TITLE
feat: ブースト（リブログ）投稿の表示に対応

### DIFF
--- a/src/main/timeline.ts
+++ b/src/main/timeline.ts
@@ -24,24 +24,37 @@ export async function fetchTimeline(
       break;
   }
 
-  return statuses.map((status) => ({
-    id: status.id,
-    content: status.content,
-    createdAt: status.createdAt,
-    url: status.url ?? null,
-    account: {
-      acct: status.account.acct,
-      displayName: status.account.displayName,
-      avatarUrl: status.account.avatar,
-    },
-    mediaAttachments: status.mediaAttachments
-      .filter((m) => m.url != null && m.previewUrl != null)
-      .map((m) => ({
-        id: m.id,
-        type: m.type,
-        url: m.url!,
-        previewUrl: m.previewUrl!,
-        description: m.description ?? null,
-      })),
-  }));
+  return statuses.map((status) => {
+    // If this is a reblog, use the original post's content
+    const original = status.reblog ?? status;
+    const rebloggedBy = status.reblog
+      ? {
+          acct: status.account.acct,
+          displayName: status.account.displayName,
+          avatarUrl: status.account.avatar,
+        }
+      : undefined;
+
+    return {
+      id: status.id,
+      content: original.content,
+      createdAt: original.createdAt,
+      url: original.url ?? null,
+      account: {
+        acct: original.account.acct,
+        displayName: original.account.displayName,
+        avatarUrl: original.account.avatar,
+      },
+      mediaAttachments: original.mediaAttachments
+        .filter((m) => m.url != null && m.previewUrl != null)
+        .map((m) => ({
+          id: m.id,
+          type: m.type,
+          url: m.url!,
+          previewUrl: m.previewUrl!,
+          description: m.description ?? null,
+        })),
+      rebloggedBy,
+    };
+  });
 }

--- a/src/renderer/components/MediaGallery.tsx
+++ b/src/renderer/components/MediaGallery.tsx
@@ -15,8 +15,8 @@ const Grid = styled.div`
 `;
 
 const Thumbnail = styled.img`
-  width: 100px;
-  height: 100px;
+  width: 150px;
+  height: 150px;
   object-fit: cover;
   border-radius: 4px;
   cursor: pointer;

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -1,3 +1,4 @@
+import { RetweetOutlined } from '@ant-design/icons';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import type { Post } from '../../shared/types.ts';
@@ -14,11 +15,46 @@ const PostContainer = styled.div`
   border-bottom: 1px solid #f0f0f0;
 `;
 
+const AvatarColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 48px;
+`;
+
 const Avatar = styled.img`
   width: 48px;
   height: 48px;
   border-radius: 4px;
   flex-shrink: 0;
+`;
+
+const BoosterBadge = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-top: 4px;
+`;
+
+const BoosterAvatar = styled.img`
+  width: 25px;
+  height: 25px;
+  border-radius: 2px;
+`;
+
+const BoostIcon = styled(RetweetOutlined)`
+  font-size: 12px;
+  color: #52c41a;
+`;
+
+const BoostInfo = styled.div`
+  margin-top: 4px;
+  font-size: 12px;
+  color: #52c41a;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;
 
 const Content = styled.div`
@@ -118,7 +154,15 @@ export function PostItem({ post }: PostItemProps): React.JSX.Element {
 
   return (
     <PostContainer>
-      <Avatar src={post.account.avatarUrl} alt={post.account.acct} />
+      <AvatarColumn>
+        <Avatar src={post.account.avatarUrl} alt={post.account.acct} />
+        {post.rebloggedBy && (
+          <BoosterBadge>
+            <BoosterAvatar src={post.rebloggedBy.avatarUrl} alt={post.rebloggedBy.acct} />
+            <BoostIcon />
+          </BoosterBadge>
+        )}
+      </AvatarColumn>
       <Content>
         <HeaderLine>
           <Acct>@{post.account.acct}</Acct>
@@ -132,6 +176,12 @@ export function PostItem({ post }: PostItemProps): React.JSX.Element {
           </Timestamp>
         ) : (
           <Timestamp as="span">{formatTimestamp(post.createdAt)}</Timestamp>
+        )}
+        {post.rebloggedBy && (
+          <BoostInfo>
+            <RetweetOutlined />
+            <span>@{post.rebloggedBy.acct} boost this</span>
+          </BoostInfo>
         )}
       </Content>
     </PostContainer>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -64,6 +64,12 @@ export interface Post {
   };
   /** Media attachments (images, videos, etc.) */
   mediaAttachments: PostMediaAttachment[];
+  /** If this post is a boost, info about who boosted it */
+  rebloggedBy?: {
+    acct: string;
+    displayName: string;
+    avatarUrl: string;
+  };
 }
 
 /** Parameters for fetching a timeline */


### PR DESCRIPTION
close #5 

## Summary
- リブログ（ブースト）投稿をタイムラインに表示する際、オリジナル投稿の内容を表示しブーストしたユーザー情報を付加
- アバター下にブーストしたユーザーのバッジアイコンを表示
- サムネイル画像サイズを100pxから150pxに拡大

## Test plan
- [x] タイムラインでブースト投稿が正しく表示されることを確認
- [x] ブースト投稿でオリジナル投稿の本文・画像・アカウント情報が表示されることを確認
- [x] ブーストしたユーザーのアバターとアイコンがアバター下に表示されることを確認
- [x] 通常の投稿（非ブースト）が従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)