### PR TITLE
feat: 通知タブの追加

### DIFF
--- a/.serena/memories/plan/issue-14-notification-tab.md
+++ b/.serena/memories/plan/issue-14-notification-tab.md
@@ -1,0 +1,68 @@
+# Issue #14: 通知タブの追加プラン
+
+## 概要
+タイムラインの追加ダイアログで「通知」タブを追加できるようにする。
+対応する通知タイプ: フォロー、フォローリクエスト、お気に入り、ブースト
+
+## 実装方針
+
+通知はタイムライン(Post[])とはデータ構造が異なるため、専用の型・取得ロジック・表示コンポーネントが必要。
+TabDefinition の timelineType を拡張して 'notifications' を追加し、通知タブの場合は専用コンテンツを表示する。
+
+## 実装ステップ
+
+### Step 1: 共通型定義の追加 (`src/shared/types.ts`)
+- `TimelineType` に `'notifications'` を追加
+- `Notification` 型を新規追加:
+  ```ts
+  export type NotificationType = 'follow' | 'follow_request' | 'favourite' | 'reblog';
+  export interface MastoNotification {
+    id: string;
+    type: NotificationType;
+    createdAt: string;
+    account: { acct: string; displayName: string; avatarUrl: string };
+    /** お気に入り・ブーストの場合、対象の投稿 */
+    status?: Post;
+  }
+  ```
+- `NotificationFetchParams` 型を追加(serverUrl, accessToken, maxId?)
+
+### Step 2: IPC チャンネル追加 (`src/shared/ipc.ts`)
+- `NotificationsFetch: 'notifications:fetch'` を追加
+
+### Step 3: メインプロセス — 通知取得 (`src/main/notifications.ts`)
+- `fetchNotifications(serverUrl, accessToken, maxId?)` 関数を実装
+  - `masto` の `client.v1.notifications.list()` を使用
+  - フィルタ: `types: ['follow', 'follow_request', 'favourite', 'reblog']`
+  - `mastodon.v1.Notification` → `MastoNotification` にマッピング
+
+### Step 4: IPC ハンドラー登録 (`src/main/index.ts`)
+- `NotificationsFetch` ハンドラーを追加
+
+### Step 5: preload 拡張 (`src/preload/index.ts`)
+- `fetchNotifications(params)` を `window.api` に追加
+
+### Step 6: 通知アイテムコンポーネント (`src/renderer/components/NotificationItem.tsx`)
+- 通知タイプに応じた表示:
+  - follow: 「{user}にフォローされました」
+  - follow_request: 「{user}からフォローリクエスト」
+  - favourite: 「{user}がお気に入りに追加」+ 対象投稿のプレビュー
+  - reblog: 「{user}がブースト」+ 対象投稿のプレビュー
+
+### Step 7: 通知タブコンテンツ (`src/renderer/pages/TimelinePage.tsx`)
+- `NotificationTabContent` コンポーネントを追加
+  - TimelineTabContent と同様の構造だが、通知用のAPIを呼び出し
+  - NotificationItem で各通知を表示
+- タブの children で timelineType === 'notifications' の場合に NotificationTabContent を使用
+
+### Step 8: タブ追加ダイアログの拡張 (`src/renderer/pages/TimelinePage.tsx`)
+- `TIMELINE_TYPE_LABELS` に `notifications: 'Notifications'` を追加
+- `timelineTypeOptions` に `{ value: 'notifications', label: 'Notifications' }` を追加
+
+### Step 9: フォーマット・Lint・型チェック
+- `bun run format` + `bun run lint:fix` + `bun run typecheck`
+
+## 技術的注意点
+- 通知APIは `client.v1.notifications.list({ types: [...] })` で呼べる
+- TabDefinition の timelineType を 'home' | 'public' | 'favourites' | 'notifications' に拡張
+- TimelineFetchParams は通知には使わない(専用の NotificationFetchParams を用意)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import path from 'node:path';
 import { IpcChannels } from '../shared/ipc.ts';
 import type {
+  NotificationFetchParams,
   OAuthExchangeTokenParams,
   TabDefinition,
   TimelineFetchParams,
@@ -9,6 +10,7 @@ import type {
 import { startLogin, exchangeToken } from './oauth.ts';
 import { listAccounts, addAccount, removeAccount } from './accounts.ts';
 import { fetchTimeline } from './timeline.ts';
+import { fetchNotifications } from './notifications.ts';
 import { listTabs, saveTabs } from './tabs.ts';
 
 function createWindow(): void {
@@ -73,6 +75,13 @@ function registerIpcHandlers(): void {
   ipcMain.handle(IpcChannels.TimelineFetch, async (_event, params: TimelineFetchParams) => {
     return fetchTimeline(params.serverUrl, params.accessToken, params.type, params.maxId);
   });
+
+  ipcMain.handle(
+    IpcChannels.NotificationsFetch,
+    async (_event, params: NotificationFetchParams) => {
+      return fetchNotifications(params.serverUrl, params.accessToken, params.maxId);
+    },
+  );
 
   ipcMain.handle(IpcChannels.TabsList, async () => {
     return listTabs();

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -1,0 +1,60 @@
+import { createRestAPIClient } from 'masto';
+import type { MastoNotification, Post } from '../shared/types.ts';
+
+const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
+
+export async function fetchNotifications(
+  serverUrl: string,
+  accessToken: string,
+  maxId?: string,
+): Promise<MastoNotification[]> {
+  const client = createRestAPIClient({ url: serverUrl, accessToken });
+
+  const notifications = await client.v1.notifications.list({
+    maxId,
+    limit: 20,
+    types: [...NOTIFICATION_TYPES],
+  });
+
+  return notifications
+    .filter((n) => NOTIFICATION_TYPES.includes(n.type as (typeof NOTIFICATION_TYPES)[number]))
+    .map((n) => {
+      const result: MastoNotification = {
+        id: n.id,
+        type: n.type as MastoNotification['type'],
+        createdAt: n.createdAt,
+        account: {
+          acct: n.account.acct,
+          displayName: n.account.displayName,
+          avatarUrl: n.account.avatar,
+        },
+      };
+
+      if (n.status) {
+        const original = n.status.reblog ?? n.status;
+        const status: Post = {
+          id: n.status.id,
+          content: original.content,
+          createdAt: original.createdAt,
+          url: original.url ?? null,
+          account: {
+            acct: original.account.acct,
+            displayName: original.account.displayName,
+            avatarUrl: original.account.avatar,
+          },
+          mediaAttachments: original.mediaAttachments
+            .filter((m) => m.url != null && m.previewUrl != null)
+            .map((m) => ({
+              id: m.id,
+              type: m.type,
+              url: m.url!,
+              previewUrl: m.previewUrl!,
+              description: m.description ?? null,
+            })),
+        };
+        result.status = status;
+      }
+
+      return result;
+    });
+}

--- a/src/main/timeline.ts
+++ b/src/main/timeline.ts
@@ -22,6 +22,8 @@ export async function fetchTimeline(
     case 'favourites':
       statuses = await client.v1.favourites.list(params);
       break;
+    case 'notifications':
+      return [];
   }
 
   return statuses.map((status) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,8 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { IpcChannels } from '../shared/ipc.ts';
 import type {
   Account,
+  MastoNotification,
+  NotificationFetchParams,
   OAuthStartLoginResult,
   OAuthExchangeTokenParams,
   TabDefinition,
@@ -29,6 +31,10 @@ const api = {
   /** Fetch timeline posts */
   fetchTimeline(params: TimelineFetchParams): Promise<Post[]> {
     return ipcRenderer.invoke(IpcChannels.TimelineFetch, params);
+  },
+  /** Fetch notifications */
+  fetchNotifications(params: NotificationFetchParams): Promise<MastoNotification[]> {
+    return ipcRenderer.invoke(IpcChannels.NotificationsFetch, params);
   },
   /** Get the list of saved tabs */
   listTabs(): Promise<TabDefinition[]> {

--- a/src/renderer/components/NotificationItem.tsx
+++ b/src/renderer/components/NotificationItem.tsx
@@ -1,0 +1,130 @@
+import {
+  HeartFilled,
+  RetweetOutlined,
+  UserAddOutlined,
+  QuestionCircleOutlined,
+} from '@ant-design/icons';
+import sanitizeHtml from 'sanitize-html';
+import styled from 'styled-components';
+import type { MastoNotification, NotificationType } from '../../shared/types.ts';
+
+interface NotificationItemProps {
+  notification: MastoNotification;
+}
+
+const NotificationContainer = styled.div`
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #f0f0f0;
+`;
+
+const Avatar = styled.img`
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  flex-shrink: 0;
+`;
+
+const Content = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const NotificationHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  font-size: 14px;
+`;
+
+const Acct = styled.span`
+  font-weight: 600;
+`;
+
+const NotificationMessage = styled.span`
+  color: #8c8c8c;
+`;
+
+const StatusPreview = styled.div`
+  margin-top: 8px;
+  padding: 8px 12px;
+  border-left: 3px solid #d9d9d9;
+  font-size: 13px;
+  color: #595959;
+  line-height: 1.5;
+
+  p {
+    margin: 0 0 4px;
+  }
+
+  a {
+    color: #1677ff;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const Timestamp = styled.span`
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: #8c8c8c;
+`;
+
+const NOTIFICATION_ICON: Record<NotificationType, React.ReactNode> = {
+  follow: <UserAddOutlined style={{ color: '#1677ff' }} />,
+  follow_request: <QuestionCircleOutlined style={{ color: '#faad14' }} />,
+  favourite: <HeartFilled style={{ color: '#eb2f96' }} />,
+  reblog: <RetweetOutlined style={{ color: '#52c41a' }} />,
+};
+
+const NOTIFICATION_LABEL: Record<NotificationType, string> = {
+  follow: 'にフォローされました',
+  follow_request: 'からフォローリクエスト',
+  favourite: 'がお気に入りに追加',
+  reblog: 'がブースト',
+};
+
+function formatTimestamp(isoString: string): string {
+  const d = new Date(isoString);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function sanitizeContent(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: ['a', 'br', 'p', 'span', 'em', 'strong', 'b', 'i', 'u'],
+    allowedAttributes: {
+      a: ['href', 'rel', 'target', 'class'],
+      span: ['class'],
+    },
+  });
+}
+
+export function NotificationItem({ notification }: NotificationItemProps): React.JSX.Element {
+  return (
+    <NotificationContainer>
+      <Avatar src={notification.account.avatarUrl} alt={notification.account.acct} />
+      <Content>
+        <NotificationHeader>
+          {NOTIFICATION_ICON[notification.type]}
+          <span>
+            <Acct>@{notification.account.acct}</Acct>
+            <NotificationMessage>{NOTIFICATION_LABEL[notification.type]}</NotificationMessage>
+          </span>
+        </NotificationHeader>
+        {notification.status && (
+          <StatusPreview
+            dangerouslySetInnerHTML={{ __html: sanitizeContent(notification.status.content) }}
+          />
+        )}
+        <Timestamp>{formatTimestamp(notification.createdAt)}</Timestamp>
+      </Content>
+    </NotificationContainer>
+  );
+}

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -2,8 +2,15 @@ import { useState, useEffect, useCallback } from 'react';
 import { Tabs, Modal, Select, Button, App, Flex, Typography, Spin } from 'antd';
 import { SettingOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
-import type { Account, Post, TabDefinition, TimelineType } from '../../shared/types.ts';
+import type {
+  Account,
+  MastoNotification,
+  Post,
+  TabDefinition,
+  TimelineType,
+} from '../../shared/types.ts';
 import { PostItem } from '../components/PostItem.tsx';
+import { NotificationItem } from '../components/NotificationItem.tsx';
 
 const { Text } = Typography;
 
@@ -38,6 +45,7 @@ const TIMELINE_TYPE_LABELS: Record<TimelineType, string> = {
   home: 'Home',
   public: 'Public',
   favourites: 'Favourites',
+  notifications: 'Notifications',
 };
 
 function generateTabId(): string {
@@ -113,6 +121,79 @@ function TimelineTabContent({
       ))}
     </TimelineList>
   );
+}
+
+function NotificationTabContent({
+  tab,
+  accounts,
+}: {
+  tab: TabDefinition;
+  accounts: Account[];
+}): React.JSX.Element {
+  const { message } = App.useApp();
+  const [notifications, setNotifications] = useState<MastoNotification[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const account = accounts.find(
+    (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
+  );
+
+  const loadNotifications = useCallback(async () => {
+    if (!account) return;
+    setLoading(true);
+    try {
+      const result = await window.api.fetchNotifications({
+        serverUrl: account.serverUrl,
+        accessToken: account.accessToken,
+      });
+      setNotifications(result);
+    } catch (e) {
+      message.error(`通知の取得に失敗しました: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [account, message]);
+
+  useEffect(() => {
+    loadNotifications();
+  }, [loadNotifications]);
+
+  if (!account) {
+    return <EmptyMessage>アカウントが見つかりません</EmptyMessage>;
+  }
+
+  if (loading && notifications.length === 0) {
+    return (
+      <SpinContainer>
+        <Spin />
+      </SpinContainer>
+    );
+  }
+
+  if (notifications.length === 0) {
+    return <EmptyMessage>通知はありません</EmptyMessage>;
+  }
+
+  return (
+    <TimelineList>
+      {notifications.map((notification) => (
+        <NotificationItem key={notification.id} notification={notification} />
+      ))}
+    </TimelineList>
+  );
+}
+
+function TabContent({
+  tab,
+  accounts,
+}: {
+  tab: TabDefinition;
+  accounts: Account[];
+}): React.JSX.Element {
+  if (tab.timelineType === 'notifications') {
+    return <NotificationTabContent tab={tab} accounts={accounts} />;
+  }
+  return <TimelineTabContent tab={tab} accounts={accounts} />;
 }
 
 export function TimelinePage({
@@ -197,13 +278,14 @@ export function TimelinePage({
     { value: 'home', label: 'Home' },
     { value: 'public', label: 'Public' },
     { value: 'favourites', label: 'Favourites' },
+    { value: 'notifications', label: 'Notifications' },
   ];
 
   const tabItems = [
     ...tabs.map((tab) => ({
       key: tab.id,
       label: buildTabLabel(tab, accounts),
-      children: <TimelineTabContent tab={tab} accounts={accounts} />,
+      children: <TabContent tab={tab} accounts={accounts} />,
       closable: tabs.length > 1,
     })),
   ];

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,6 +10,8 @@ export const IpcChannels = {
   AccountsRemove: 'accounts:remove',
   /** Fetch timeline posts */
   TimelineFetch: 'timeline:fetch',
+  /** Fetch notifications */
+  NotificationsFetch: 'notifications:fetch',
   /** Get the list of saved tabs */
   TabsList: 'tabs:list',
   /** Save the current tabs */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,7 +31,7 @@ export interface OAuthExchangeTokenParams {
 }
 
 /** Timeline type */
-export type TimelineType = 'home' | 'public' | 'favourites';
+export type TimelineType = 'home' | 'public' | 'favourites' | 'notifications';
 
 /** Media attachment type */
 export type MediaAttachmentType = 'image' | 'video' | 'gifv' | 'audio' | 'unknown';
@@ -87,4 +87,27 @@ export interface TabDefinition {
   accountServerUrl: string;
   accountUsername: string;
   timelineType: TimelineType;
+}
+
+export type NotificationType = 'follow' | 'follow_request' | 'favourite' | 'reblog';
+
+export interface MastoNotification {
+  id: string;
+  type: NotificationType;
+  /** ISO 8601 timestamp */
+  createdAt: string;
+  account: {
+    acct: string;
+    displayName: string;
+    avatarUrl: string;
+  };
+  /** The target post for favourite/reblog notifications */
+  status?: Post;
+}
+
+export interface NotificationFetchParams {
+  serverUrl: string;
+  accessToken: string;
+  /** For pagination — fetch notifications older than this ID */
+  maxId?: string;
 }


### PR DESCRIPTION
close #14 

## Summary
- タイムラインの追加ダイアログで「Notifications」を選択して通知タブを追加できるようにした
- フォロー、フォローリクエスト、お気に入り、ブースト通知の表示に対応
- 通知タイプごとにアイコン・ラベルを表示し、お気に入り/ブーストは対象投稿のプレビューも表示

## Test plan
- [x] タブ追加ダイアログで「Notifications」を選択してタブを追加できること
- [x] フォロー通知が正しく表示されること
- [x] フォローリクエスト通知が正しく表示されること
- [x] お気に入り通知が対象投稿のプレビュー付きで表示されること
- [x] ブースト通知が対象投稿のプレビュー付きで表示されること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)