### PR TITLE
feat: ウィンドウサイズと位置の永続化を実装

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,12 +16,11 @@ import { fetchNotifications } from './notifications.ts';
 import { listTabs, saveTabs } from './tabs.ts';
 import { subscribeStream, unsubscribeStream, unsubscribeAllStreams } from './streaming.ts';
 import { createStatus } from './statuses.ts';
+import { createMainWindowOptions, restoreMaximizeState, saveWindowState } from './windowState.ts';
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({
-    width: 900,
-    height: 670,
-    show: true,
+    ...createMainWindowOptions(),
     webPreferences: {
       preload: path.join(__dirname, '../preload/index.js'),
       contextIsolation: true,
@@ -31,6 +30,11 @@ function createWindow(): void {
 
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
+  });
+
+  restoreMaximizeState(mainWindow);
+  mainWindow.on('close', () => {
+    saveWindowState(mainWindow);
   });
 
   // Open external links in the default browser

--- a/src/main/windowState.ts
+++ b/src/main/windowState.ts
@@ -1,0 +1,101 @@
+import { app, type BrowserWindow, type BrowserWindowConstructorOptions } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_WINDOW_SIZE = {
+  width: 900,
+  height: 670,
+};
+
+interface WindowState {
+  width: number;
+  height: number;
+  x?: number;
+  y?: number;
+  isMaximized: boolean;
+}
+
+function getWindowStateFilePath(): string {
+  return path.join(app.getPath('userData'), 'window-state.json');
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isValidWindowState(value: unknown): value is WindowState {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<WindowState>;
+  if (!isNumber(candidate.width) || !isNumber(candidate.height)) {
+    return false;
+  }
+
+  if (candidate.width <= 0 || candidate.height <= 0) {
+    return false;
+  }
+
+  if (candidate.x !== undefined && !isNumber(candidate.x)) {
+    return false;
+  }
+
+  if (candidate.y !== undefined && !isNumber(candidate.y)) {
+    return false;
+  }
+
+  return typeof candidate.isMaximized === 'boolean';
+}
+
+function readWindowState(): WindowState | null {
+  const filePath = getWindowStateFilePath();
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as unknown;
+    if (!isValidWindowState(parsed)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function createMainWindowOptions(): BrowserWindowConstructorOptions {
+  const state = readWindowState();
+
+  return {
+    width: state?.width ?? DEFAULT_WINDOW_SIZE.width,
+    height: state?.height ?? DEFAULT_WINDOW_SIZE.height,
+    x: state?.x,
+    y: state?.y,
+    show: true,
+  };
+}
+
+export function restoreMaximizeState(mainWindow: BrowserWindow): void {
+  if (readWindowState()?.isMaximized) {
+    mainWindow.maximize();
+  }
+}
+
+export function saveWindowState(mainWindow: BrowserWindow): void {
+  const filePath = getWindowStateFilePath();
+  const isMaximized = mainWindow.isMaximized();
+  const bounds = isMaximized ? mainWindow.getNormalBounds() : mainWindow.getBounds();
+
+  const state: WindowState = {
+    width: bounds.width,
+    height: bounds.height,
+    x: bounds.x,
+    y: bounds.y,
+    isMaximized,
+  };
+
+  fs.writeFileSync(filePath, JSON.stringify(state, null, 2), 'utf-8');
+}


### PR DESCRIPTION
### Motivation
- Issue #8 に対応し、アプリ終了時のウィンドウサイズ・位置・最大化状態を保存して次回起動時に復元することでユーザー体験を向上させるため。 
- 保存データが壊れている場合や未保存の場合は安全にデフォルト値へフォールバックする必要があったため。

### Description
- 新規に `src/main/windowState.ts` を追加し、`userData/window-state.json` への読み書きと保存データのバリデーション、および `createMainWindowOptions` / `restoreMaximizeState` / `saveWindowState` を実装しました。 
- `src/main/index.ts` を更新して、`BrowserWindow` 作成時に `createMainWindowOptions()` を適用し、起動時に `restoreMaximizeState()` を呼び、ウィンドウの `close` イベントで `saveWindowState()` を呼び出すようにしました。 
- 既存のデフォルトサイズは維持しつつ、不正な保存データは読み飛ばす設計により安全に動作するようにしています。

### Testing
- `bun run format` を実行してコード整形を行い成功しました。 
- `bun run lint` を実行して ESLint チェックが成功しました。 
- `bun run typecheck` を実行して TypeScript の型チェックが成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a01941bdec832ba35820d6068f4074)