### PR TITLE
feat: マルチペイン表示を実装

### DIFF
--- a/.serena/memories/plan/issue-12-multi-pane.md
+++ b/.serena/memories/plan/issue-12-multi-pane.md
@@ -1,0 +1,76 @@
+# Issue #12: マルチペイン化 実装プラン
+
+## 概要
+横にペインを並べる画面分割を可能にする。ペインのサイズはユーザーが調節可能で保存される。
+
+## 要件
+1. 複数ペインを横並びに表示
+2. ペインサイズをドラッグで調節可能 → サイズを永続化
+3. 左端・右端に新しいペインの追加ボタン
+4. タブラベルの左端を押すと左右のペインに移動する選択肢を表示
+
+## データモデル
+
+### 新しい型 (`src/shared/types.ts`)
+```typescript
+interface PaneDefinition {
+  id: string;
+  tabIds: string[];       // このペイン内のタブID一覧（順序付き）
+  activeTabId: string;    // このペインでアクティブなタブ
+  widthRatio: number;     // ペインの幅比率（合計を1.0として正規化）
+}
+
+interface PaneLayout {
+  panes: PaneDefinition[];
+}
+```
+
+- `TabDefinition` は変更なし（既存のまま）
+- `PaneLayout` がどのタブがどのペインにあるかを管理
+
+## 実装ステップ
+
+### Step 1: 型定義の追加
+- `src/shared/types.ts` に `PaneDefinition`, `PaneLayout` を追加
+
+### Step 2: IPC チャンネルの追加
+- `src/shared/ipc.ts` に `PaneLayoutSave`, `PaneLayoutLoad` チャンネルを追加
+
+### Step 3: メインプロセスにペインレイアウト永続化を追加
+- `src/main/panes.ts` を新規作成 — `pane-layout.json` への読み書き
+- `src/main/index.ts` に IPC ハンドラを登録
+
+### Step 4: プリロードにAPI追加
+- `src/preload/index.ts` に `savePaneLayout` / `loadPaneLayout` を追加
+- `window.api` の型定義も更新
+
+### Step 5: リサイズ可能なペインコンテナの実装
+- `src/renderer/components/PaneContainer.tsx` を新規作成
+  - flexbox で横並びレイアウト
+  - ペイン間にドラッグ可能なディバイダー（幅4px程度）
+  - ドラッグでペインの `widthRatio` を調節
+  - 左端・右端に「＋」ボタンでペイン追加
+
+### Step 6: TimelinePage のリファクタリング
+- 現在の単一 `Tabs` を `PaneContainer` + 複数 `Pane` に変更
+- 各ペインが独自の `Tabs` コンポーネントを持つ
+- タブの追加は対象ペイン内で行う
+- タブの削除時、ペインが空になったらペインも削除（最後の1ペインは残す）
+
+### Step 7: タブ移動機能の実装
+- タブラベルの左端にアイコンボタンを追加
+- クリックで Dropdown メニュー表示：「左のペインへ移動」「右のペインへ移動」
+- 移動先ペインがない場合は新しいペインを作成して移動
+
+### Step 8: レイアウト永続化
+- ペインレイアウト変更時（リサイズ・タブ移動・ペイン追加/削除）に `savePaneLayout` を呼ぶ
+- 起動時に `loadPaneLayout` でレイアウトを復元
+
+## ファイル変更一覧
+- `src/shared/types.ts` — 型追加
+- `src/shared/ipc.ts` — IPCチャンネル追加
+- `src/main/panes.ts` — 新規: ペインレイアウト永続化
+- `src/main/index.ts` — IPCハンドラ登録
+- `src/preload/index.ts` — API追加
+- `src/renderer/components/PaneContainer.tsx` — 新規: リサイズ可能なペインコンテナ
+- `src/renderer/pages/TimelinePage.tsx` — マルチペイン対応にリファクタリング

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import type {
   AppSettings,
   NotificationFetchParams,
   OAuthExchangeTokenParams,
+  PaneLayout,
   StatusActionParams,
   StatusCreateParams,
   StreamSubscribeParams,
@@ -17,6 +18,7 @@ import { fetchTimeline } from './timeline.ts';
 import { fetchNotifications } from './notifications.ts';
 import { listTabs, saveTabs } from './tabs.ts';
 import { loadSettings, saveSettings } from './settings.ts';
+import { loadPaneLayout, savePaneLayout } from './panes.ts';
 import { subscribeStream, unsubscribeStream, unsubscribeAllStreams } from './streaming.ts';
 import {
   createStatus,
@@ -152,6 +154,14 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(IpcChannels.SettingsSave, async (_event, settings: AppSettings) => {
     saveSettings(settings);
+  });
+
+  ipcMain.handle(IpcChannels.PaneLayoutLoad, async () => {
+    return loadPaneLayout();
+  });
+
+  ipcMain.handle(IpcChannels.PaneLayoutSave, async (_event, layout: PaneLayout) => {
+    savePaneLayout(layout);
   });
 }
 

--- a/src/main/panes.ts
+++ b/src/main/panes.ts
@@ -1,0 +1,23 @@
+import { app } from 'electron';
+import path from 'node:path';
+import fs from 'node:fs';
+import type { PaneLayout } from '../shared/types.ts';
+
+/** File where pane layout data is stored */
+function getPaneLayoutFilePath(): string {
+  return path.join(app.getPath('userData'), 'pane-layout.json');
+}
+
+export function loadPaneLayout(): PaneLayout | null {
+  const filePath = getPaneLayoutFilePath();
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const data = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(data) as PaneLayout;
+}
+
+export function savePaneLayout(layout: PaneLayout): void {
+  const filePath = getPaneLayoutFilePath();
+  fs.writeFileSync(filePath, JSON.stringify(layout, null, 2), 'utf-8');
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   NotificationFetchParams,
   OAuthStartLoginResult,
   OAuthExchangeTokenParams,
+  PaneLayout,
   StatusActionParams,
   StatusCreateParams,
   StreamEventData,
@@ -92,6 +93,14 @@ const api = {
   /** Save application settings */
   saveSettings(settings: AppSettings): Promise<void> {
     return ipcRenderer.invoke(IpcChannels.SettingsSave, settings);
+  },
+  /** Load pane layout */
+  loadPaneLayout(): Promise<PaneLayout | null> {
+    return ipcRenderer.invoke(IpcChannels.PaneLayoutLoad);
+  },
+  /** Save pane layout */
+  savePaneLayout(layout: PaneLayout): Promise<void> {
+    return ipcRenderer.invoke(IpcChannels.PaneLayoutSave, layout);
   },
   /** Listen for streaming events */
   onStreamEvent(callback: (event: StreamEventData) => void): () => void {

--- a/src/renderer/components/PaneContainer.tsx
+++ b/src/renderer/components/PaneContainer.tsx
@@ -1,0 +1,147 @@
+import { useRef, useCallback } from 'react';
+import { Button } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+
+interface PaneContainerProps {
+  paneCount: number;
+  widthRatios: number[];
+  onWidthRatiosChange: (ratios: number[]) => void;
+  onAddPane: (position: 'left' | 'right') => void;
+  children: React.ReactNode[];
+}
+
+const Container = styled.div`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+`;
+
+const PaneWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+const Divider = styled.div`
+  width: 4px;
+  cursor: col-resize;
+  background: #303030;
+  flex-shrink: 0;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #1668dc;
+  }
+`;
+
+const AddPaneButton = styled(Button)`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  width: 24px;
+  height: 48px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+const AddPaneButtonLeft = styled(AddPaneButton)`
+  left: 0;
+`;
+
+const AddPaneButtonRight = styled(AddPaneButton)`
+  right: 0;
+`;
+
+export function PaneContainer({
+  paneCount,
+  widthRatios,
+  onWidthRatiosChange,
+  onAddPane,
+  children,
+}: PaneContainerProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = useCallback(
+    (dividerIndex: number, e: React.MouseEvent) => {
+      e.preventDefault();
+      const container = containerRef.current;
+      if (!container) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const containerWidth = containerRect.width;
+      const startX = e.clientX;
+      const startRatios = [...widthRatios];
+
+      const handleMouseMove = (moveEvent: MouseEvent): void => {
+        const deltaX = moveEvent.clientX - startX;
+        const deltaRatio = deltaX / containerWidth;
+
+        const newRatios = [...startRatios];
+        const leftRatio = (startRatios[dividerIndex] ?? 0) + deltaRatio;
+        const rightRatio = (startRatios[dividerIndex + 1] ?? 0) - deltaRatio;
+
+        const minRatio = 0.1;
+        if (leftRatio < minRatio || rightRatio < minRatio) return;
+
+        newRatios[dividerIndex] = leftRatio;
+        newRatios[dividerIndex + 1] = rightRatio;
+        onWidthRatiosChange(newRatios);
+      };
+
+      const handleMouseUp = (): void => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [widthRatios, onWidthRatiosChange],
+  );
+
+  const elements: React.ReactNode[] = [];
+  for (let i = 0; i < paneCount; i++) {
+    if (i > 0) {
+      elements.push(
+        <Divider key={`divider-${i}`} onMouseDown={(e) => handleMouseDown(i - 1, e)} />,
+      );
+    }
+    elements.push(
+      <PaneWrapper key={`pane-${i}`} style={{ flex: widthRatios[i] ?? 1 }}>
+        {children[i]}
+      </PaneWrapper>,
+    );
+  }
+
+  return (
+    <Container ref={containerRef}>
+      <AddPaneButtonLeft
+        type="default"
+        icon={<PlusOutlined />}
+        onClick={() => onAddPane('left')}
+        title="左にペインを追加"
+      />
+      {elements}
+      <AddPaneButtonRight
+        type="default"
+        icon={<PlusOutlined />}
+        onClick={() => onAddPane('right')}
+        title="右にペインを追加"
+      />
+    </Container>
+  );
+}

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Tabs, Modal, Select, Button, App, Flex, Typography, Spin } from 'antd';
-import { SettingOutlined, UserOutlined } from '@ant-design/icons';
+import { Tabs, Modal, Select, Button, App, Flex, Typography, Spin, Dropdown } from 'antd';
+import { SettingOutlined, UserOutlined, SwapOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import type {
   Account,
   MastoNotification,
+  PaneDefinition,
   Post,
   StreamType,
   TabDefinition,
@@ -13,6 +14,7 @@ import type {
 import { PostItem } from '../components/PostItem.tsx';
 import { NotificationItem } from '../components/NotificationItem.tsx';
 import { Composer } from '../components/Composer.tsx';
+import { PaneContainer } from '../components/PaneContainer.tsx';
 
 const { Text } = Typography;
 
@@ -44,6 +46,35 @@ const SpinContainer = styled.div`
   text-align: center;
 `;
 
+const StyledTabs = styled(Tabs)`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+
+  .ant-tabs-content-holder {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .ant-tabs-content {
+    height: 100%;
+  }
+
+  .ant-tabs-tabpane-active {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+`;
+
+const TabLabelWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+`;
+
 const TIMELINE_TYPE_LABELS: Record<TimelineType, string> = {
   home: 'Home',
   public: 'Public',
@@ -51,7 +82,7 @@ const TIMELINE_TYPE_LABELS: Record<TimelineType, string> = {
   notifications: 'Notifications',
 };
 
-function generateTabId(): string {
+function generateId(): string {
   return crypto.randomUUID();
 }
 
@@ -269,79 +300,340 @@ function TabContent({
   return <TimelineTabContent tab={tab} accounts={accounts} />;
 }
 
+interface PaneProps {
+  pane: PaneDefinition;
+  paneIndex: number;
+  totalPanes: number;
+  tabs: TabDefinition[];
+  accounts: Account[];
+  onActiveTabChange: (paneId: string, tabId: string) => void;
+  onAddTab: (paneId: string) => void;
+  onRemoveTab: (paneId: string, tabId: string) => void;
+  onMoveTab: (tabId: string, fromPaneId: string, direction: 'left' | 'right') => void;
+}
+
+function Pane({
+  pane,
+  paneIndex,
+  totalPanes,
+  tabs,
+  accounts,
+  onActiveTabChange,
+  onAddTab,
+  onRemoveTab,
+  onMoveTab,
+}: PaneProps): React.JSX.Element {
+  const paneTabs = pane.tabIds
+    .map((id) => tabs.find((t) => t.id === id))
+    .filter((t): t is TabDefinition => t !== undefined);
+
+  const tabItems = paneTabs.map((tab) => {
+    const moveMenuItems = [];
+    if (paneIndex > 0 || totalPanes > 1) {
+      moveMenuItems.push({
+        key: 'left',
+        label: '左のペインへ移動',
+        disabled: paneIndex === 0,
+      });
+    }
+    if (paneIndex < totalPanes - 1 || totalPanes > 1) {
+      moveMenuItems.push({
+        key: 'right',
+        label: '右のペインへ移動',
+        disabled: paneIndex === totalPanes - 1,
+      });
+    }
+
+    return {
+      key: tab.id,
+      label: (
+        <TabLabelWrapper>
+          {totalPanes > 1 && (
+            <Dropdown
+              menu={{
+                items: moveMenuItems,
+                onClick: ({ key }) => {
+                  onMoveTab(tab.id, pane.id, key as 'left' | 'right');
+                },
+              }}
+              trigger={['click']}
+            >
+              <SwapOutlined
+                style={{ fontSize: 10, cursor: 'pointer' }}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </Dropdown>
+          )}
+          {buildTabLabel(tab, accounts)}
+        </TabLabelWrapper>
+      ),
+      children: <TabContent tab={tab} accounts={accounts} />,
+      closable: paneTabs.length > 1 || totalPanes > 1,
+    };
+  });
+
+  return (
+    <StyledTabs
+      type="editable-card"
+      activeKey={pane.activeTabId}
+      onChange={(key) => onActiveTabChange(pane.id, key)}
+      onEdit={(targetKey, action) => {
+        if (action === 'add') {
+          onAddTab(pane.id);
+        } else if (action === 'remove' && typeof targetKey === 'string') {
+          onRemoveTab(pane.id, targetKey);
+        }
+      }}
+      items={
+        tabItems.length > 0
+          ? tabItems
+          : [
+              {
+                key: '__empty__',
+                label: '',
+                children: <EmptyMessage>「＋」ボタンからタブを追加してください</EmptyMessage>,
+                closable: false,
+                disabled: true,
+              },
+            ]
+      }
+    />
+  );
+}
+
 export function TimelinePage({
   accounts,
   onNavigateToLogin,
   onNavigateToSettings,
 }: TimelinePageProps): React.JSX.Element {
   const [tabs, setTabs] = useState<TabDefinition[]>([]);
-  const [activeTabId, setActiveTabId] = useState<string>('');
+  const [panes, setPanes] = useState<PaneDefinition[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  // Modal state
   const [modalOpen, setModalOpen] = useState(false);
+  const [modalPaneId, setModalPaneId] = useState<string>('');
   const [newTabAccount, setNewTabAccount] = useState<string>('');
   const [newTabType, setNewTabType] = useState<TimelineType>('home');
-  const [tabsLoaded, setTabsLoaded] = useState(false);
 
-  // Load saved tabs on mount
+  // Load saved data on mount
   useEffect(() => {
-    window.api.listTabs().then((savedTabs) => {
-      if (savedTabs.length > 0) {
-        setTabs(savedTabs);
-        setActiveTabId(savedTabs[0]?.id ?? '');
-      }
-      setTabsLoaded(true);
-    });
+    Promise.all([window.api.listTabs(), window.api.loadPaneLayout()]).then(
+      ([savedTabs, savedLayout]) => {
+        if (savedTabs.length > 0 && savedLayout && savedLayout.panes.length > 0) {
+          setTabs(savedTabs);
+          setPanes(savedLayout.panes);
+        } else if (savedTabs.length > 0) {
+          // Migrate: existing tabs but no pane layout
+          setTabs(savedTabs);
+          const defaultPane: PaneDefinition = {
+            id: generateId(),
+            tabIds: savedTabs.map((t) => t.id),
+            activeTabId: savedTabs[0]?.id ?? '',
+            widthRatio: 1,
+          };
+          setPanes([defaultPane]);
+        }
+        setLoaded(true);
+      },
+    );
   }, []);
 
   // Initialize with a default tab if accounts exist and no saved tabs
   useEffect(() => {
-    if (!tabsLoaded) return;
+    if (!loaded) return;
     const firstAccount = accounts[0];
     if (firstAccount && tabs.length === 0) {
       const defaultTab: TabDefinition = {
-        id: generateTabId(),
+        id: generateId(),
         accountServerUrl: firstAccount.serverUrl,
         accountUsername: firstAccount.username,
         timelineType: 'home',
       };
+      const defaultPane: PaneDefinition = {
+        id: generateId(),
+        tabIds: [defaultTab.id],
+        activeTabId: defaultTab.id,
+        widthRatio: 1,
+      };
       setTabs([defaultTab]);
-      setActiveTabId(defaultTab.id);
+      setPanes([defaultPane]);
       window.api.saveTabs([defaultTab]);
+      window.api.savePaneLayout({ panes: [defaultPane] });
     }
-  }, [accounts, tabs.length, tabsLoaded]);
+  }, [accounts, tabs.length, loaded]);
 
-  const handleAddTab = (): void => {
+  const persistLayout = useCallback((newTabs: TabDefinition[], newPanes: PaneDefinition[]) => {
+    window.api.saveTabs(newTabs);
+    window.api.savePaneLayout({ panes: newPanes });
+  }, []);
+
+  const handleActiveTabChange = useCallback((paneId: string, tabId: string) => {
+    setPanes((prev) => {
+      const next = prev.map((p) => (p.id === paneId ? { ...p, activeTabId: tabId } : p));
+      window.api.savePaneLayout({ panes: next });
+      return next;
+    });
+  }, []);
+
+  const handleAddTab = useCallback(
+    (paneId: string) => {
+      setModalPaneId(paneId);
+      const firstOption = accounts[0];
+      if (firstOption) {
+        setNewTabAccount(`${firstOption.serverUrl}|${firstOption.username}`);
+      }
+      setModalOpen(true);
+    },
+    [accounts],
+  );
+
+  const handleConfirmAddTab = useCallback((): void => {
     if (!newTabAccount) return;
     const parts = newTabAccount.split('|');
     const serverUrl = parts[0] ?? '';
     const username = parts[1] ?? '';
     const tab: TabDefinition = {
-      id: generateTabId(),
+      id: generateId(),
       accountServerUrl: serverUrl,
       accountUsername: username,
       timelineType: newTabType,
     };
-    setTabs((prev) => {
-      const next = [...prev, tab];
-      window.api.saveTabs(next);
-      return next;
+
+    setTabs((prevTabs) => {
+      const nextTabs = [...prevTabs, tab];
+      setPanes((prevPanes) => {
+        const nextPanes = prevPanes.map((p) =>
+          p.id === modalPaneId ? { ...p, tabIds: [...p.tabIds, tab.id], activeTabId: tab.id } : p,
+        );
+        persistLayout(nextTabs, nextPanes);
+        return nextPanes;
+      });
+      return nextTabs;
     });
-    setActiveTabId(tab.id);
+
     setModalOpen(false);
     setNewTabAccount('');
     setNewTabType('home');
-  };
+  }, [newTabAccount, newTabType, modalPaneId, persistLayout]);
 
-  const handleRemoveTab = (tabId: string): void => {
-    setTabs((prev) => {
-      const next = prev.filter((t) => t.id !== tabId);
-      const firstRemaining = next[0];
-      if (activeTabId === tabId && firstRemaining) {
-        setActiveTabId(firstRemaining.id);
-      }
-      window.api.saveTabs(next);
-      return next;
+  const handleRemoveTab = useCallback(
+    (paneId: string, tabId: string): void => {
+      setPanes((prevPanes) => {
+        const pane = prevPanes.find((p) => p.id === paneId);
+        if (!pane) return prevPanes;
+
+        const newTabIds = pane.tabIds.filter((id) => id !== tabId);
+
+        // If pane becomes empty, remove the pane (unless it's the last one)
+        if (newTabIds.length === 0 && prevPanes.length > 1) {
+          const nextPanes = prevPanes.filter((p) => p.id !== paneId);
+          // Normalize width ratios
+          const totalRatio = nextPanes.reduce((sum, p) => sum + p.widthRatio, 0);
+          const normalizedPanes = nextPanes.map((p) => ({
+            ...p,
+            widthRatio: p.widthRatio / totalRatio,
+          }));
+
+          setTabs((prevTabs) => {
+            const nextTabs = prevTabs.filter((t) => t.id !== tabId);
+            persistLayout(nextTabs, normalizedPanes);
+            return nextTabs;
+          });
+          return normalizedPanes;
+        }
+
+        const newActiveTabId = pane.activeTabId === tabId ? (newTabIds[0] ?? '') : pane.activeTabId;
+
+        const nextPanes = prevPanes.map((p) =>
+          p.id === paneId ? { ...p, tabIds: newTabIds, activeTabId: newActiveTabId } : p,
+        );
+
+        setTabs((prevTabs) => {
+          const nextTabs = prevTabs.filter((t) => t.id !== tabId);
+          persistLayout(nextTabs, nextPanes);
+          return nextTabs;
+        });
+        return nextPanes;
+      });
+    },
+    [persistLayout],
+  );
+
+  const handleMoveTab = useCallback(
+    (tabId: string, fromPaneId: string, direction: 'left' | 'right'): void => {
+      setPanes((prevPanes) => {
+        const fromIndex = prevPanes.findIndex((p) => p.id === fromPaneId);
+        if (fromIndex === -1) return prevPanes;
+
+        const toIndex = direction === 'left' ? fromIndex - 1 : fromIndex + 1;
+        if (toIndex < 0 || toIndex >= prevPanes.length) return prevPanes;
+
+        const fromPane = prevPanes[fromIndex]!;
+        const toPane = prevPanes[toIndex]!;
+
+        const newFromTabIds = fromPane.tabIds.filter((id) => id !== tabId);
+        const newFromActiveTabId =
+          fromPane.activeTabId === tabId ? (newFromTabIds[0] ?? '') : fromPane.activeTabId;
+
+        let nextPanes = prevPanes.map((p, i) => {
+          if (i === fromIndex) {
+            return { ...p, tabIds: newFromTabIds, activeTabId: newFromActiveTabId };
+          }
+          if (i === toIndex) {
+            return { ...p, tabIds: [...toPane.tabIds, tabId], activeTabId: tabId };
+          }
+          return p;
+        });
+
+        // Remove empty panes (unless it's the last one)
+        if (newFromTabIds.length === 0 && nextPanes.length > 1) {
+          nextPanes = nextPanes.filter((p) => p.id !== fromPaneId);
+          const totalRatio = nextPanes.reduce((sum, p) => sum + p.widthRatio, 0);
+          nextPanes = nextPanes.map((p) => ({
+            ...p,
+            widthRatio: p.widthRatio / totalRatio,
+          }));
+        }
+
+        window.api.savePaneLayout({ panes: nextPanes });
+        return nextPanes;
+      });
+    },
+    [],
+  );
+
+  const handleWidthRatiosChange = useCallback((ratios: number[]): void => {
+    setPanes((prevPanes) => {
+      const nextPanes = prevPanes.map((p, i) => ({
+        ...p,
+        widthRatio: ratios[i] ?? p.widthRatio,
+      }));
+      window.api.savePaneLayout({ panes: nextPanes });
+      return nextPanes;
     });
-  };
+  }, []);
+
+  const handleAddPane = useCallback((position: 'left' | 'right'): void => {
+    const newPane: PaneDefinition = {
+      id: generateId(),
+      tabIds: [],
+      activeTabId: '',
+      widthRatio: 1,
+    };
+
+    setPanes((prevPanes) => {
+      const nextPanes = position === 'left' ? [newPane, ...prevPanes] : [...prevPanes, newPane];
+      // Normalize ratios
+      const totalRatio = nextPanes.reduce((sum, p) => sum + p.widthRatio, 0);
+      const normalizedPanes = nextPanes.map((p) => ({
+        ...p,
+        widthRatio: p.widthRatio / totalRatio,
+      }));
+      window.api.savePaneLayout({ panes: normalizedPanes });
+      return normalizedPanes;
+    });
+  }, []);
 
   const accountOptions = accounts.map((a) => ({
     value: `${a.serverUrl}|${a.username}`,
@@ -355,61 +647,52 @@ export function TimelinePage({
     { value: 'notifications', label: 'Notifications' },
   ];
 
-  const tabItems = [
-    ...tabs.map((tab) => ({
-      key: tab.id,
-      label: buildTabLabel(tab, accounts),
-      children: <TabContent tab={tab} accounts={accounts} />,
-      closable: tabs.length > 1,
-    })),
-  ];
+  const widthRatios = panes.map((p) => p.widthRatio);
 
   return (
     <PageContainer>
       <Composer accounts={accounts} />
-      <Tabs
-        type="editable-card"
-        activeKey={activeTabId}
-        onChange={setActiveTabId}
-        onEdit={(targetKey, action) => {
-          if (action === 'add') {
-            const firstOption = accountOptions[0];
-            if (firstOption) {
-              setNewTabAccount(firstOption.value);
-            }
-            setModalOpen(true);
-          } else if (action === 'remove' && typeof targetKey === 'string') {
-            handleRemoveTab(targetKey);
-          }
-        }}
-        items={tabItems}
-        tabBarExtraContent={{
-          right: (
-            <>
-              <Button
-                type="text"
-                icon={<SettingOutlined />}
-                onClick={onNavigateToSettings}
-                title="設定"
-                style={{ marginRight: 4 }}
-              />
-              <Button
-                type="text"
-                icon={<UserOutlined />}
-                onClick={onNavigateToLogin}
-                title="アカウント管理"
-                style={{ marginRight: 8 }}
-              />
-            </>
-          ),
-        }}
-        style={{ flex: 1, display: 'flex', flexDirection: 'column' }}
-      />
+      <Flex align="center" justify="flex-end" style={{ padding: '0 8px', flexShrink: 0 }}>
+        <Button
+          type="text"
+          icon={<SettingOutlined />}
+          onClick={onNavigateToSettings}
+          title="設定"
+          style={{ marginRight: 4 }}
+        />
+        <Button
+          type="text"
+          icon={<UserOutlined />}
+          onClick={onNavigateToLogin}
+          title="アカウント管理"
+        />
+      </Flex>
+      <PaneContainer
+        paneCount={panes.length}
+        widthRatios={widthRatios}
+        onWidthRatiosChange={handleWidthRatiosChange}
+        onAddPane={handleAddPane}
+      >
+        {panes.map((pane, index) => (
+          <Pane
+            key={pane.id}
+            pane={pane}
+            paneIndex={index}
+            totalPanes={panes.length}
+            tabs={tabs}
+            accounts={accounts}
+            onActiveTabChange={handleActiveTabChange}
+            onAddTab={handleAddTab}
+            onRemoveTab={handleRemoveTab}
+            onMoveTab={handleMoveTab}
+          />
+        ))}
+      </PaneContainer>
 
       <Modal
         title="タブを追加"
         open={modalOpen}
-        onOk={handleAddTab}
+        onOk={handleConfirmAddTab}
         onCancel={() => setModalOpen(false)}
         okText="追加"
         cancelText="キャンセル"

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -40,4 +40,8 @@ export const IpcChannels = {
   SettingsLoad: 'settings:load',
   /** Save application settings */
   SettingsSave: 'settings:save',
+  /** Load pane layout */
+  PaneLayoutLoad: 'pane-layout:load',
+  /** Save pane layout */
+  PaneLayoutSave: 'pane-layout:save',
 } as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -97,6 +97,17 @@ export interface TabDefinition {
   timelineType: TimelineType;
 }
 
+export interface PaneDefinition {
+  id: string;
+  tabIds: string[];
+  activeTabId: string;
+  widthRatio: number;
+}
+
+export interface PaneLayout {
+  panes: PaneDefinition[];
+}
+
 export type StreamType = 'user' | 'public';
 
 export interface StreamSubscribeParams {


### PR DESCRIPTION
## Summary
- 横にペインを並べる画面分割機能を追加。各ペインが独自のタブセットを持つ
- ペイン間のディバイダーをドラッグしてサイズを調節可能、レイアウトは自動保存
- 左端・右端の「＋」ボタンで新しいペインを追加（空の状態で作成）
- タブラベルのアイコンから左右のペインへタブを移動可能

## Test plan
- [x] ペインの追加（左端・右端）ができること
- [x] 各ペインでタブの追加・削除ができること
- [x] ディバイダーのドラッグでペインサイズが変更できること
- [x] タブを左右のペインに移動できること
- [x] アプリ再起動後にペインレイアウト（サイズ・タブ配置）が復元されること
- [x] 既存のタブデータからの移行（1ペインに全タブ配置）が正しく動作すること
- [x] タイムラインのスクロールが正常に動作すること

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)