### PR TITLE
feat: Implement Content Warning (CW) support — hide/show post body and media (Issue 35)

### DIFF
--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -35,6 +35,8 @@ export async function fetchNotifications(
         const status: Post = {
           id: n.status.id,
           content: original.content,
+          spoilerText: original.spoilerText,
+          sensitive: original.sensitive,
           createdAt: original.createdAt,
           url: original.url ?? null,
           visibility: original.visibility as PostVisibility,

--- a/src/main/streaming.ts
+++ b/src/main/streaming.ts
@@ -32,6 +32,8 @@ function convertStatus(status: mastodon.v1.Status): Post {
   return {
     id: status.id,
     content: original.content,
+    spoilerText: original.spoilerText,
+    sensitive: original.sensitive,
     createdAt: original.createdAt,
     url: original.url ?? null,
     visibility: original.visibility as PostVisibility,

--- a/src/main/timeline.ts
+++ b/src/main/timeline.ts
@@ -40,6 +40,8 @@ export async function fetchTimeline(
     return {
       id: status.id,
       content: original.content,
+      spoilerText: original.spoilerText,
+      sensitive: original.sensitive,
       createdAt: original.createdAt,
       url: original.url ?? null,
       visibility: original.visibility as PostVisibility,

--- a/src/renderer/components/MediaGallery.tsx
+++ b/src/renderer/components/MediaGallery.tsx
@@ -5,6 +5,8 @@ import type { PostMediaAttachment } from '../../shared/types.ts';
 
 interface MediaGalleryProps {
   attachments: PostMediaAttachment[];
+  hidden?: boolean;
+  onReveal?: () => void;
 }
 
 const Grid = styled.div`
@@ -27,17 +29,40 @@ const Thumbnail = styled.img`
   }
 `;
 
+const HiddenMediaButton = styled.button`
+  margin-top: 8px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 1px solid #d9d9d9;
+  background: #fafafa;
+  color: #595959;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #1677ff;
+    color: #1677ff;
+  }
+`;
+
 const PreviewImage = styled.img`
   width: 100%;
   max-height: 80vh;
   object-fit: contain;
 `;
 
-export function MediaGallery({ attachments }: MediaGalleryProps): React.JSX.Element | null {
+export function MediaGallery({
+  attachments,
+  hidden = false,
+  onReveal,
+}: MediaGalleryProps): React.JSX.Element | null {
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
 
   const images = attachments.filter((a) => a.type === 'image');
   if (images.length === 0) return null;
+
+  if (hidden) {
+    return <HiddenMediaButton onClick={onReveal}>センシティブ画像を表示</HiddenMediaButton>;
+  }
 
   const previewImage = previewIndex !== null ? images[previewIndex] : null;
 

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -109,6 +109,23 @@ const PostBody = styled.div<{ $fontSize: number }>`
   }
 `;
 
+const ContentWarning = styled.button<{ $fontSize: number }>`
+  margin-bottom: 8px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid #d9d9d9;
+  background: #fafafa;
+  color: #262626;
+  font-size: ${(props) => props.$fontSize}px;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #1677ff;
+    color: #1677ff;
+  }
+`;
+
 const FooterLine = styled.div`
   display: flex;
   align-items: center;
@@ -186,6 +203,8 @@ export function PostItem({ post, serverUrl, accessToken }: PostItemProps): React
   const [favourited, setFavourited] = useState(post.favourited);
   const [reblogged, setReblogged] = useState(post.reblogged);
   const [bookmarked, setBookmarked] = useState(post.bookmarked);
+  const hasContentWarning = post.spoilerText.trim().length > 0;
+  const [expanded, setExpanded] = useState(!hasContentWarning && !post.sensitive);
 
   const actionParams = { serverUrl, accessToken, statusId: post.id };
   const reblogDisabled = post.visibility === 'private' || post.visibility === 'direct';
@@ -228,6 +247,8 @@ export function PostItem({ post, serverUrl, accessToken }: PostItemProps): React
   };
 
   const smallFontSize = settings.uiFontSize - 2;
+  const shouldHideContent = hasContentWarning && !expanded;
+  const shouldHideMedia = (hasContentWarning || post.sensitive) && !expanded;
 
   return (
     <PostContainer>
@@ -249,11 +270,25 @@ export function PostItem({ post, serverUrl, accessToken }: PostItemProps): React
           <Acct $fontSize={settings.uiFontSize}>@{post.account.acct}</Acct>
           <DisplayName $fontSize={settings.uiFontSize}>{post.account.displayName}</DisplayName>
         </HeaderLine>
-        <PostBody
-          $fontSize={settings.postFontSize}
-          dangerouslySetInnerHTML={{ __html: sanitizeContent(post.content) }}
-        />
-        {post.mediaAttachments.length > 0 && <MediaGallery attachments={post.mediaAttachments} />}
+        {(hasContentWarning || post.sensitive) && (
+          <ContentWarning $fontSize={settings.postFontSize} onClick={() => setExpanded(!expanded)}>
+            {hasContentWarning ? post.spoilerText : 'センシティブな内容が含まれます'}
+            {expanded ? '（クリックで隠す）' : '（クリックで表示）'}
+          </ContentWarning>
+        )}
+        {!shouldHideContent && (
+          <PostBody
+            $fontSize={settings.postFontSize}
+            dangerouslySetInnerHTML={{ __html: sanitizeContent(post.content) }}
+          />
+        )}
+        {post.mediaAttachments.length > 0 && (
+          <MediaGallery
+            attachments={post.mediaAttachments}
+            hidden={shouldHideMedia}
+            onReveal={() => setExpanded(true)}
+          />
+        )}
         <FooterLine>
           {post.url ? (
             <Timestamp $fontSize={smallFontSize} href={post.url} onClick={handleTimestampClick}>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,6 +53,10 @@ export interface Post {
   id: string;
   /** HTML content */
   content: string;
+  /** Content warning text */
+  spoilerText: string;
+  /** Whether media should be treated as sensitive */
+  sensitive: boolean;
   /** ISO 8601 timestamp */
   createdAt: string;
   /** Original URL of the post (may be null for some posts) */


### PR DESCRIPTION
### Motivation

- Mastodon supports Content Warnings (CW) and sensitive media which should be hidden by default until the user chooses to reveal them. 
- Timeline, streaming and notification conversions must preserve `spoilerText`/`sensitive` so the renderer can decide whether to hide content and media.

### Description

- Added `spoilerText: string` and `sensitive: boolean` to the `Post` type in `src/shared/types.ts` and mapped these fields from Mastodon responses in timeline/notifications/streaming converters (`src/main/timeline.ts`, `src/main/notifications.ts`, `src/main/streaming.ts`).
- Implemented CW UI in `PostItem` (`src/renderer/components/PostItem.tsx`) which displays a toggle button showing `spoilerText` (or a generic sensitive label), and conditionally hides/shows the post body and media based on `spoilerText`/`sensitive` and an `expanded` state. 
- Extended `MediaGallery` (`src/renderer/components/MediaGallery.tsx`) with `hidden` and `onReveal` props so media can be replaced by a “show sensitive images” button and revealed when requested.
- Minor styling additions for the CW toggle and hidden-media button to match existing UI patterns.

### Testing

- Ran `bun install` successfully to ensure dependencies were present. 
- Ran `bun run format` and `bun run lint` successfully to apply formatting and verify linting. 
- Ran `bun run typecheck` (`tsc -b`) successfully after installing dependencies. 
- Attempted `bun run dev -- --host 0.0.0.0 --port 4173`, but `electron-vite dev` failed due to the provided `--host` option being unsupported by the CLI, so full live dev startup was not completed (the CW UI is implemented and type-checked, but manual runtime verification in the dev environment was blocked by the CLI option mismatch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a11e8c9310832b8315a8cd87d8d4ef)