### PR TITLE
feat: 書き込みエリアを縮小しメニューバーを非表示化

### DIFF
--- a/.serena/memories/plan/issue-46-compact-compose.md
+++ b/.serena/memories/plan/issue-46-compact-compose.md
@@ -1,0 +1,35 @@
+# Issue #46: 書き込みエリアを縮小する
+
+## 概要
+トゥートボタンと公開範囲の設定を本文欄の右に置くことで書き込みコンポーネントの高さを縮小する。
+
+## 現状のレイアウト
+```
+[Avatar] [     TextArea      ]
+         [Select]    [Button]
+```
+- TextArea の下に FooterRow があり、Select（公開範囲）と Button（トゥート）が横並び
+- FooterRow の分だけ高さが大きくなっている
+
+## 変更後のレイアウト
+```
+[Avatar] [   TextArea   ] [Select]
+                          [Button]
+```
+- TextArea の右側に公開範囲 Select とトゥートボタンを縦に配置
+- FooterRow を廃止し、ComposerRight 内で TextArea と操作パネルを横並びにする
+
+## 実装手順
+
+### 1. styled-components の変更
+- `FooterRow` を削除
+- `ComposerRight` を flex 横並びに変更（TextArea部分 + 操作パネル部分）
+- 新しい `ActionColumn` styled-component を追加（Select + Button を縦に並べる）
+
+### 2. Composer コンポーネントの JSX 変更
+- `ComposerRight` 内を TextArea と ActionColumn の横並びに変更
+- ActionColumn 内に Select と Button を縦に配置
+- Select の幅を調整（コンパクトに）
+
+## 対象ファイル
+- `src/renderer/components/Composer.tsx`

--- a/src/main/windowState.ts
+++ b/src/main/windowState.ts
@@ -75,6 +75,7 @@ export function createMainWindowOptions(): BrowserWindowConstructorOptions {
     x: state?.x,
     y: state?.y,
     show: true,
+    autoHideMenuBar: true,
   };
 }
 

--- a/src/renderer/components/Composer.tsx
+++ b/src/renderer/components/Composer.tsx
@@ -24,13 +24,16 @@ const ComposerBody = styled.div`
 const ComposerRight = styled.div`
   flex: 1;
   min-width: 0;
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
 `;
 
-const FooterRow = styled.div`
-  margin-top: 8px;
+const ActionColumn = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
 `;
 
 const visibilityOptions: { value: PostVisibility; label: string }[] = [
@@ -116,16 +119,18 @@ export function Composer({ accounts }: ComposerProps): React.JSX.Element {
               }
             }}
             placeholder="いまどうしてる？"
-            autoSize={{ minRows: 3, maxRows: 6 }}
+            autoSize={{ minRows: 2, maxRows: 6 }}
             maxLength={500}
+            style={{ flex: 1 }}
           />
 
-          <FooterRow>
+          <ActionColumn>
             <Select
               value={visibility}
               options={visibilityOptions}
               onChange={setVisibility}
-              style={{ width: 180 }}
+              size="small"
+              style={{ width: 140 }}
             />
 
             <Button
@@ -133,10 +138,11 @@ export function Composer({ accounts }: ComposerProps): React.JSX.Element {
               onClick={() => void handleSubmit()}
               disabled={!selectedAccount || text.trim().length === 0}
               loading={submitting}
+              style={{ flex: 1 }}
             >
               トゥート
             </Button>
-          </FooterRow>
+          </ActionColumn>
         </ComposerRight>
       </ComposerBody>
     </Container>

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -651,21 +651,26 @@ export function TimelinePage({
 
   return (
     <PageContainer>
-      <Composer accounts={accounts} />
-      <Flex align="center" justify="flex-end" style={{ padding: '0 8px', flexShrink: 0 }}>
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={onNavigateToSettings}
-          title="設定"
-          style={{ marginRight: 4 }}
-        />
-        <Button
-          type="text"
-          icon={<UserOutlined />}
-          onClick={onNavigateToLogin}
-          title="アカウント管理"
-        />
+      <Flex align="flex-start" style={{ flexShrink: 0 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <Composer accounts={accounts} />
+        </div>
+        <Flex vertical align="center" style={{ padding: '8px 4px 0 0', flexShrink: 0 }}>
+          <Button
+            type="text"
+            icon={<SettingOutlined />}
+            onClick={onNavigateToSettings}
+            title="設定"
+            size="small"
+          />
+          <Button
+            type="text"
+            icon={<UserOutlined />}
+            onClick={onNavigateToLogin}
+            title="アカウント管理"
+            size="small"
+          />
+        </Flex>
       </Flex>
       <PaneContainer
         paneCount={panes.length}


### PR DESCRIPTION
## Summary
- トゥートボタンと公開範囲Selectを本文TextAreaの右側に縦配置し、Composerの高さを縮小
- 設定・アカウント管理ボタンをComposerの右上に移動
- `autoHideMenuBar: true` でメニューバーを非表示化

## Test plan
- [x] 書き込みエリアが以前より縦にコンパクトになっていることを確認
- [x] 公開範囲の変更・トゥート投稿が正常に動作すること
- [x] 設定ボタン・アカウント管理ボタンが画面右上に表示され、クリックで遷移すること
- [x] メニューバーが非表示になっていること（Altキーで一時表示可能）

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)