### PR TITLE
feat: TLの縮小表示を実装

### DIFF
--- a/.serena/memories/plan/issue-6-compact-timeline.md
+++ b/.serena/memories/plan/issue-6-compact-timeline.md
@@ -1,0 +1,47 @@
+# Issue #6: TLの縮小表示の実装
+
+## 概要
+1ポスト分の表示が1行になるような超縮小表示を実装する。
+
+## 要件
+- デフォルトは縮小表示（1行）
+- クリックすると通常のフル表示になる
+- 別のポストをクリックすると他のポストは縮小表示に戻る
+- 縮小表示はグリッド型レイアウトで固定幅
+  - アイコンセル: 緑背景
+  - アカウント名セル: 黄色背景
+  - 本文セル: 水色背景
+- アイコンを横長に細くクロップして一番左に表示
+- acctのホスト名を省略してその右に表示
+- 本文をその右に1行で表示（長い場合は「...」で切る）
+- フル表示でユーザーアイコンをクリックすると縮小表示に戻る
+- 画像添付がある場合は右端に画像アイコンを表示
+
+## 実装方針
+
+### 1. CompactPostItem コンポーネントの新規作成
+`src/renderer/components/CompactPostItem.tsx`
+
+- 縮小表示用の1行コンポーネント
+- グリッドレイアウト: `[アイコン(24px)] [acct(120px)] [本文(flex)] [画像アイコン(24px)]`
+- 各セルに背景色を設定（緑/黄色/水色）
+- アイコンは横長にクロップ（object-fit: cover, 幅24px, 高さ16px程度）
+- acctはホスト名を省略（`@` + ユーザー名のみ）
+- 本文はHTMLからテキスト抽出し、1行に制限（text-overflow: ellipsis）
+- 画像添付がある場合は PictureOutlined アイコンを右端に表示
+- クリックで `onExpand` コールバックを呼ぶ
+
+### 2. TimelineTabContent の状態管理
+- `expandedPostId` state を追加（展開中のポストID、null で全て縮小）
+- ポストクリックで `expandedPostId` を更新
+- 展開中のポストは既存の `PostItem` で表示
+- フル表示の PostItem のアイコンクリックで縮小に戻す
+
+### 3. PostItem の変更
+- `onCollapse` prop を追加
+- アバタークリックで `onCollapse` を呼ぶ（cursor: pointer に）
+
+## 対象ファイル
+- `src/renderer/components/CompactPostItem.tsx` (新規)
+- `src/renderer/components/PostItem.tsx` (onCollapse prop 追加)
+- `src/renderer/pages/TimelinePage.tsx` (expandedPostId 状態管理)

--- a/src/renderer/components/CompactPostItem.tsx
+++ b/src/renderer/components/CompactPostItem.tsx
@@ -1,0 +1,112 @@
+import { PictureOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+import type { Post } from '../../shared/types.ts';
+
+interface CompactPostItemProps {
+  post: Post;
+  onClick: () => void;
+}
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: 28px 100px 1fr;
+  align-items: center;
+  height: 24px;
+  cursor: pointer;
+  border-bottom: 1px solid #f0f0f0;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+`;
+
+const IconCell = styled.div`
+  background: #d9f7be;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+`;
+
+const CompactAvatar = styled.img`
+  width: 26px;
+  height: 18px;
+  object-fit: cover;
+  border-radius: 2px;
+`;
+
+const AcctCell = styled.div<{ $boosted: boolean }>`
+  background: ${(props) => (props.$boosted ? '#fff1f0' : '#fffbe6')};
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+  overflow: hidden;
+`;
+
+const AcctText = styled.span`
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const BodyCell = styled.div<{ $visibility: string }>`
+  background: ${(props) => {
+    if (props.$visibility === 'direct') return '#f9f0ff';
+    if (props.$visibility === 'private') return '#f6ffed';
+    return '#e6f7ff';
+  }};
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  overflow: hidden;
+`;
+
+const BodyText = styled.span`
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const MediaIcon = styled(PictureOutlined)`
+  font-size: 12px;
+  color: #8c8c8c;
+  flex-shrink: 0;
+  margin-left: 4px;
+`;
+
+function stripHtml(html: string): string {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent ?? '';
+}
+
+function shortAcct(acct: string): string {
+  const atIndex = acct.indexOf('@');
+  if (atIndex === -1) return `@${acct}`;
+  return `@${acct.substring(0, atIndex)}`;
+}
+
+export function CompactPostItem({ post, onClick }: CompactPostItemProps): React.JSX.Element {
+  const plainText = stripHtml(post.content);
+  const hasMedia = post.mediaAttachments.length > 0;
+
+  return (
+    <Row onClick={onClick}>
+      <IconCell>
+        <CompactAvatar src={post.account.avatarUrl} alt={post.account.acct} />
+      </IconCell>
+      <AcctCell $boosted={!!post.rebloggedBy}>
+        <AcctText>{shortAcct(post.account.acct)}</AcctText>
+      </AcctCell>
+      <BodyCell $visibility={post.visibility}>
+        <BodyText>{plainText}</BodyText>
+        {hasMedia && <MediaIcon />}
+      </BodyCell>
+    </Row>
+  );
+}

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -16,6 +16,7 @@ interface PostItemProps {
   post: Post;
   serverUrl: string;
   accessToken: string;
+  onCollapse?: () => void;
 }
 
 const PostContainer = styled.div`
@@ -198,7 +199,12 @@ function sanitizeContent(html: string): string {
   });
 }
 
-export function PostItem({ post, serverUrl, accessToken }: PostItemProps): React.JSX.Element {
+export function PostItem({
+  post,
+  serverUrl,
+  accessToken,
+  onCollapse,
+}: PostItemProps): React.JSX.Element {
   const { settings } = useSettings();
   const [favourited, setFavourited] = useState(post.favourited);
   const [reblogged, setReblogged] = useState(post.reblogged);
@@ -253,7 +259,13 @@ export function PostItem({ post, serverUrl, accessToken }: PostItemProps): React
   return (
     <PostContainer>
       <AvatarColumn $width={settings.avatarSize}>
-        <Avatar $size={settings.avatarSize} src={post.account.avatarUrl} alt={post.account.acct} />
+        <Avatar
+          $size={settings.avatarSize}
+          src={post.account.avatarUrl}
+          alt={post.account.acct}
+          onClick={onCollapse}
+          style={onCollapse ? { cursor: 'pointer' } : undefined}
+        />
         {post.rebloggedBy && (
           <BoosterBadge>
             <BoosterAvatar

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -14,6 +14,7 @@ import type {
 import { PostItem } from '../components/PostItem.tsx';
 import { NotificationItem } from '../components/NotificationItem.tsx';
 import { Composer } from '../components/Composer.tsx';
+import { CompactPostItem } from '../components/CompactPostItem.tsx';
 import { PaneContainer } from '../components/PaneContainer.tsx';
 
 const { Text } = Typography;
@@ -115,6 +116,7 @@ function TimelineTabContent({
   const { message } = App.useApp();
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
+  const [expandedPostId, setExpandedPostId] = useState<string | null>(null);
 
   const account = accounts.find(
     (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
@@ -190,14 +192,19 @@ function TimelineTabContent({
 
   return (
     <TimelineList>
-      {posts.map((post) => (
-        <PostItem
-          key={post.id}
-          post={post}
-          serverUrl={account.serverUrl}
-          accessToken={account.accessToken}
-        />
-      ))}
+      {posts.map((post) =>
+        expandedPostId === post.id ? (
+          <PostItem
+            key={post.id}
+            post={post}
+            serverUrl={account.serverUrl}
+            accessToken={account.accessToken}
+            onCollapse={() => setExpandedPostId(null)}
+          />
+        ) : (
+          <CompactPostItem key={post.id} post={post} onClick={() => setExpandedPostId(post.id)} />
+        ),
+      )}
     </TimelineList>
   );
 }


### PR DESCRIPTION
## Summary
- 1ポスト1行の超縮小表示をデフォルトにし、クリックでフル表示に展開
- 別のポストをクリックすると他のポストは縮小表示に戻る
- フル表示のアバタークリックで縮小表示に復帰
- グリッドレイアウトでセルごとに背景色を設定（アイコン:緑、アカウント名:黄、本文:水色）
- ブースト時はアカウント名セルを赤背景、follower onlyは本文を緑背景、directは紫背景
- 画像添付がある場合は本文末尾にアイコンを表示

## Test plan
- [x] タイムラインのポストがデフォルトで1行の縮小表示になっていること
- [x] 縮小表示をクリックするとフル表示に展開されること
- [x] 別のポストをクリックすると展開中のポストが縮小に戻ること
- [x] フル表示のアバタークリックで縮小表示に戻ること
- [x] ブースト投稿のアカウント名セルが赤背景になること
- [x] follower only投稿の本文セルが緑背景になること
- [x] direct投稿の本文セルが紫背景になること
- [x] 画像添付のある投稿に画像アイコンが本文末尾に表示されること

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)