### PR TITLE
fix: 無限スクロールのAPI無限呼び出しとloadMore不発火を修正

### DIFF
--- a/.serena/memories/plan/fix-issue-19-infinite-api.md
+++ b/.serena/memories/plan/fix-issue-19-infinite-api.md
@@ -1,0 +1,23 @@
+# Fix: 無限スクロールがAPIを呼び続けるバグ
+
+## 原因分析
+無限ループの原因は依存関係の循環:
+
+1. `loadMore` の deps に `posts` と `loadingMore` が含まれる
+2. `loadMore` 実行 → `setPosts` で `posts` が更新 → `loadMore` が再生成（新しい参照）
+3. `useEffect` の deps が `[loadMore]` → effect再実行 → `checkAndLoad()` が即座に呼ばれる
+4. スクロール位置が末尾付近なら再度 `loadMore` が発火 → 2に戻る
+
+APIが空配列を返しても、`loadingMore` が true→false に変わるため `loadMore` が再生成され、
+effectが再実行されて `checkAndLoad()` → 再度API呼び出し、の無限ループになる。
+
+## 修正方針
+1. `posts` を ref で参照し `loadMore` の deps から除去
+2. `loadingMore` も ref で管理し deps から除去
+3. `hasMore` state を追加: APIが空配列を返したら false にし、以降の追加ロードを抑止
+4. `hasMore` が変わっても effect は再実行不要なので ref で管理
+
+これにより `loadMore` の参照が安定し、useEffect の不要な再実行を防ぐ。
+
+## 対象ファイル
+- `src/renderer/pages/TimelinePage.tsx`（TimelineTabContent, NotificationTabContent）

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -119,6 +119,10 @@ function TimelineTabContent({
   const [loadingMore, setLoadingMore] = useState(false);
   const [expandedPostId, setExpandedPostId] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const postsRef = useRef(posts);
+  postsRef.current = posts;
+  const loadingMoreRef = useRef(false);
+  const hasMoreRef = useRef(true);
 
   const account = accounts.find(
     (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
@@ -127,6 +131,7 @@ function TimelineTabContent({
   const loadTimeline = useCallback(async () => {
     if (!account) return;
     setLoading(true);
+    hasMoreRef.current = true;
     try {
       const result = await window.api.fetchTimeline({
         serverUrl: account.serverUrl,
@@ -144,9 +149,12 @@ function TimelineTabContent({
   }, [account, tab.timelineType, message]);
 
   const loadMore = useCallback(async () => {
-    if (!account || loadingMore || posts.length === 0) return;
-    const lastPost = posts[posts.length - 1];
+    if (!account || loadingMoreRef.current || !hasMoreRef.current) return;
+    const currentPosts = postsRef.current;
+    if (currentPosts.length === 0) return;
+    const lastPost = currentPosts[currentPosts.length - 1];
     if (!lastPost) return;
+    loadingMoreRef.current = true;
     setLoadingMore(true);
     try {
       const result = await window.api.fetchTimeline({
@@ -157,15 +165,18 @@ function TimelineTabContent({
       });
       if (result.length > 0) {
         setPosts((prev) => [...prev, ...result]);
+      } else {
+        hasMoreRef.current = false;
       }
     } catch (e) {
       message.error(
         `タイムラインの取得に失敗しました: ${e instanceof Error ? e.message : String(e)}`,
       );
     } finally {
+      loadingMoreRef.current = false;
       setLoadingMore(false);
     }
-  }, [account, tab.timelineType, posts, loadingMore, message]);
+  }, [account, tab.timelineType, message]);
 
   useEffect(() => {
     loadTimeline();
@@ -182,7 +193,7 @@ function TimelineTabContent({
     checkAndLoad();
     el.addEventListener('scroll', checkAndLoad);
     return () => el.removeEventListener('scroll', checkAndLoad);
-  }, [loadMore]);
+  }, [loadMore, posts.length]);
 
   // Subscribe to streaming for real-time updates
   useEffect(() => {
@@ -265,6 +276,10 @@ function NotificationTabContent({
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const notificationsRef = useRef(notifications);
+  notificationsRef.current = notifications;
+  const loadingMoreRef = useRef(false);
+  const hasMoreRef = useRef(true);
 
   const account = accounts.find(
     (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
@@ -273,6 +288,7 @@ function NotificationTabContent({
   const loadNotifications = useCallback(async () => {
     if (!account) return;
     setLoading(true);
+    hasMoreRef.current = true;
     try {
       const result = await window.api.fetchNotifications({
         serverUrl: account.serverUrl,
@@ -287,9 +303,12 @@ function NotificationTabContent({
   }, [account, message]);
 
   const loadMoreNotifications = useCallback(async () => {
-    if (!account || loadingMore || notifications.length === 0) return;
-    const lastNotification = notifications[notifications.length - 1];
+    if (!account || loadingMoreRef.current || !hasMoreRef.current) return;
+    const currentNotifications = notificationsRef.current;
+    if (currentNotifications.length === 0) return;
+    const lastNotification = currentNotifications[currentNotifications.length - 1];
     if (!lastNotification) return;
+    loadingMoreRef.current = true;
     setLoadingMore(true);
     try {
       const result = await window.api.fetchNotifications({
@@ -299,13 +318,16 @@ function NotificationTabContent({
       });
       if (result.length > 0) {
         setNotifications((prev) => [...prev, ...result]);
+      } else {
+        hasMoreRef.current = false;
       }
     } catch (e) {
       message.error(`通知の取得に失敗しました: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
+      loadingMoreRef.current = false;
       setLoadingMore(false);
     }
-  }, [account, notifications, loadingMore, message]);
+  }, [account, message]);
 
   useEffect(() => {
     loadNotifications();
@@ -322,7 +344,7 @@ function NotificationTabContent({
     checkAndLoad();
     el.addEventListener('scroll', checkAndLoad);
     return () => el.removeEventListener('scroll', checkAndLoad);
-  }, [loadMoreNotifications]);
+  }, [loadMoreNotifications, notifications.length]);
 
   // Subscribe to user stream for real-time notification updates
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `loadMore` / `loadMoreNotifications` の `useCallback` deps から `posts` と `loadingMore` を除去し、ref経由で参照することで関数参照を安定化
- `loadingMore` と `hasMore` を ref で管理し、無限ループを防止
- scroll用 `useEffect` の deps に `posts.length` / `notifications.length` を追加し、コンテンツロード後にスクロールリスナーが正しく登録されるよう修正

## Background
#49 で無限スクロールを実装したが、`loadMore` の deps に `posts` と `loadingMore` が含まれていたため、API呼び出し → state更新 → `loadMore`再生成 → effect再実行 → 再度API呼び出し、の無限ループが発生していた。

deps を除去して関数参照を安定させたところ、今度は初回ロード時に `listRef.current` が null（ローディング表示中）のため、スクロールリスナーが登録されず `loadMore` が一切発火しなくなる副作用があった。`posts.length` を deps に追加することで両方の問題を解決。

## Test plan
- [x] タイムラインを開き、最下部までスクロールして追加ロードが発火することを確認
- [x] コンテンツが少なくスクロールバーが出ない場合、自動で追加ロードされることを確認
- [x] APIが空配列を返した後、追加ロードが停止することを確認
- [x] 通知タブでも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)