### PR TITLE
feat: APIクライアントのキャッシュとレート制限を実装

### DIFF
--- a/.serena/memories/plan/issue-54-rate-limit.md
+++ b/.serena/memories/plan/issue-54-rate-limit.md
@@ -1,0 +1,56 @@
+# Issue #54: APIクライアントの規制対策
+
+## 課題
+- 各API呼び出しで毎回 `createRestAPIClient` を新規生成しており、レート制限の考慮がない
+- 短時間に大量のリクエストを送るとサーバーから規制される可能性がある
+
+## 現状のAPIクライアント使用箇所
+- `src/main/timeline.ts` — fetchTimeline: 毎回新規生成
+- `src/main/statuses.ts` — 7関数すべてで毎回新規生成
+- `src/main/notifications.ts` — fetchNotifications: 毎回新規生成
+- `src/main/oauth.ts` — startLogin, exchangeToken: 毎回新規生成（OAuthは対象外でよい）
+- `src/main/streaming.ts` — getStreamingApiUrl, pollUserStream, pollPublicStream: 毎回/subscription単位で生成
+
+## 設計方針
+
+### 1. `src/main/apiClient.ts` を新設
+- `serverUrl` をキーとしてREST APIクライアントをキャッシュする共有クライアントマネージャー
+- リクエストにレート制限を適用するラッパー
+- Mastodon APIのデフォルトレート制限: 300リクエスト/5分 (= 1リクエスト/秒程度)
+- トークンバケット方式で実装: サーバーURL単位で管理
+
+### 2. トークンバケットによるレート制限
+```
+class TokenBucket:
+  - capacity: 最大トークン数 (例: 300)
+  - tokens: 現在のトークン数
+  - refillRate: トークン補充レート (例: 1トークン/秒 = 300/5分)
+  - lastRefill: 最後の補充時刻
+  
+  acquire(): Promise<void>
+    - トークンがあれば即座に消費
+    - なければトークンが補充されるまで待機
+```
+
+### 3. APIクライアントマネージャー
+```
+getRestClient(serverUrl, accessToken): mastodon.rest.Client
+  - キーは `${serverUrl}::${accessToken}` 
+  - キャッシュされたクライアントがあればそれを返す
+  - なければ createRestAPIClient で生成してキャッシュ
+
+withRateLimit<T>(serverUrl, fn: () => Promise<T>): Promise<T>
+  - serverUrl単位のTokenBucketを取得/生成
+  - bucket.acquire() を待ってから fn() を実行
+```
+
+### 4. 各ファイルの修正
+- `timeline.ts`: `createRestAPIClient` → `getRestClient` + `withRateLimit`
+- `statuses.ts`: 同上
+- `notifications.ts`: 同上
+- `streaming.ts`: ポーリング用クライアントを `getRestClient` に置き換え、`withRateLimit` で制限
+- `oauth.ts`: ログインは頻度が低いのでレート制限対象外、ただしクライアントキャッシュは利用可能
+
+## 対象ファイル
+- 新規: `src/main/apiClient.ts`
+- 修正: `src/main/timeline.ts`, `src/main/statuses.ts`, `src/main/notifications.ts`, `src/main/streaming.ts`

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -1,0 +1,92 @@
+import { createRestAPIClient } from 'masto';
+import type { mastodon } from 'masto';
+
+const DEFAULT_CAPACITY = 300;
+const DEFAULT_REFILL_RATE = 1; // tokens per second (300 / 5min)
+
+class TokenBucket {
+  private tokens: number;
+  private lastRefill: number;
+  private waitQueue: (() => void)[] = [];
+
+  constructor(
+    private readonly capacity: number = DEFAULT_CAPACITY,
+    private readonly refillRate: number = DEFAULT_REFILL_RATE,
+  ) {
+    this.tokens = capacity;
+    this.lastRefill = Date.now();
+  }
+
+  async acquire(): Promise<void> {
+    this.refill();
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return;
+    }
+    const waitMs = ((1 - this.tokens) / this.refillRate) * 1000;
+    return new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+      setTimeout(() => {
+        this.refill();
+        this.tokens -= 1;
+        const idx = this.waitQueue.indexOf(resolve);
+        if (idx !== -1) {
+          this.waitQueue.splice(idx, 1);
+        }
+        resolve();
+      }, waitMs);
+    });
+  }
+
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = (now - this.lastRefill) / 1000;
+    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.refillRate);
+    this.lastRefill = now;
+  }
+}
+
+const clientCache = new Map<string, mastodon.rest.Client>();
+const buckets = new Map<string, TokenBucket>();
+
+function clientKey(serverUrl: string, accessToken: string): string {
+  return `${serverUrl}::${accessToken}`;
+}
+
+/**
+ * Get a cached REST API client for the given server and access token.
+ */
+export function getRestClient(serverUrl: string, accessToken: string): mastodon.rest.Client {
+  const key = clientKey(serverUrl, accessToken);
+  let client = clientCache.get(key);
+  if (!client) {
+    client = createRestAPIClient({ url: serverUrl, accessToken });
+    clientCache.set(key, client);
+  }
+  return client;
+}
+
+/**
+ * Remove cached clients for a specific server/token pair.
+ */
+export function removeRestClient(serverUrl: string, accessToken: string): void {
+  clientCache.delete(clientKey(serverUrl, accessToken));
+}
+
+function getBucket(serverUrl: string): TokenBucket {
+  let bucket = buckets.get(serverUrl);
+  if (!bucket) {
+    bucket = new TokenBucket();
+    buckets.set(serverUrl, bucket);
+  }
+  return bucket;
+}
+
+/**
+ * Execute an API call with rate limiting per server.
+ */
+export async function withRateLimit<T>(serverUrl: string, fn: () => PromiseLike<T>): Promise<T> {
+  const bucket = getBucket(serverUrl);
+  await bucket.acquire();
+  return fn();
+}

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -1,5 +1,5 @@
-import { createRestAPIClient } from 'masto';
 import type { MastoNotification, Post, PostVisibility } from '../shared/types.ts';
+import { getRestClient, withRateLimit } from './apiClient.ts';
 
 const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
 
@@ -8,13 +8,15 @@ export async function fetchNotifications(
   accessToken: string,
   maxId?: string,
 ): Promise<MastoNotification[]> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
+  const client = getRestClient(serverUrl, accessToken);
 
-  const notifications = await client.v1.notifications.list({
-    maxId,
-    limit: 20,
-    types: [...NOTIFICATION_TYPES],
-  });
+  const notifications = await withRateLimit(serverUrl, () =>
+    client.v1.notifications.list({
+      maxId,
+      limit: 20,
+      types: [...NOTIFICATION_TYPES],
+    }),
+  );
 
   return notifications
     .filter((n) => NOTIFICATION_TYPES.includes(n.type as (typeof NOTIFICATION_TYPES)[number]))

--- a/src/main/statuses.ts
+++ b/src/main/statuses.ts
@@ -1,5 +1,5 @@
-import { createRestAPIClient } from 'masto';
 import type { PostVisibility } from '../shared/types.ts';
+import { getRestClient, withRateLimit } from './apiClient.ts';
 
 export async function createStatus(
   serverUrl: string,
@@ -7,8 +7,8 @@ export async function createStatus(
   status: string,
   visibility: PostVisibility,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.create({ status, visibility });
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.create({ status, visibility }));
 }
 
 export async function favouriteStatus(
@@ -16,8 +16,8 @@ export async function favouriteStatus(
   accessToken: string,
   statusId: string,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.$select(statusId).favourite();
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.$select(statusId).favourite());
 }
 
 export async function unfavouriteStatus(
@@ -25,8 +25,8 @@ export async function unfavouriteStatus(
   accessToken: string,
   statusId: string,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.$select(statusId).unfavourite();
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.$select(statusId).unfavourite());
 }
 
 export async function reblogStatus(
@@ -34,8 +34,8 @@ export async function reblogStatus(
   accessToken: string,
   statusId: string,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.$select(statusId).reblog();
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.$select(statusId).reblog());
 }
 
 export async function unreblogStatus(
@@ -43,8 +43,8 @@ export async function unreblogStatus(
   accessToken: string,
   statusId: string,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.$select(statusId).unreblog();
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.$select(statusId).unreblog());
 }
 
 export async function bookmarkStatus(
@@ -52,8 +52,8 @@ export async function bookmarkStatus(
   accessToken: string,
   statusId: string,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.$select(statusId).bookmark();
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.$select(statusId).bookmark());
 }
 
 export async function unbookmarkStatus(
@@ -61,6 +61,6 @@ export async function unbookmarkStatus(
   accessToken: string,
   statusId: string,
 ): Promise<void> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
-  await client.v1.statuses.$select(statusId).unbookmark();
+  const client = getRestClient(serverUrl, accessToken);
+  await withRateLimit(serverUrl, () => client.v1.statuses.$select(statusId).unbookmark());
 }

--- a/src/main/streaming.ts
+++ b/src/main/streaming.ts
@@ -1,4 +1,4 @@
-import { createRestAPIClient, createStreamingAPIClient } from 'masto';
+import { createStreamingAPIClient } from 'masto';
 import type { mastodon } from 'masto';
 import type { WebContents } from 'electron';
 import type {
@@ -11,6 +11,7 @@ import type {
   StreamType,
 } from '../shared/types.ts';
 import { IpcChannels } from '../shared/ipc.ts';
+import { getRestClient, withRateLimit } from './apiClient.ts';
 
 const POLLING_INTERVAL_MS = 60_000;
 const STREAM_RETRY_INTERVAL_MS = 30_000;
@@ -33,7 +34,6 @@ interface ActiveSubscription {
   streaming?: StreamingHandles;
   retryTimer?: ReturnType<typeof setTimeout>;
   pollingTimer?: ReturnType<typeof setInterval>;
-  pollingClient?: mastodon.rest.Client;
   cursor: PollingCursor;
 }
 
@@ -142,8 +142,8 @@ function maxMastodonId(ids: string[]): string | undefined {
 }
 
 async function getStreamingApiUrl(serverUrl: string, accessToken: string): Promise<string> {
-  const rest = createRestAPIClient({ url: serverUrl, accessToken });
-  const instance = await rest.v2.instance.fetch();
+  const rest = getRestClient(serverUrl, accessToken);
+  const instance = await withRateLimit(serverUrl, () => rest.v2.instance.fetch());
   return instance.configuration.urls.streaming;
 }
 
@@ -186,23 +186,23 @@ function stopPolling(active: ActiveSubscription): void {
 }
 
 async function pollUserStream(active: ActiveSubscription): Promise<void> {
-  if (!active.pollingClient) {
-    active.pollingClient = createRestAPIClient({
-      url: active.params.serverUrl,
-      accessToken: active.params.accessToken,
-    });
-  }
+  const client = getRestClient(active.params.serverUrl, active.params.accessToken);
+  const { serverUrl } = active.params;
 
   const [statuses, notifications] = await Promise.all([
-    active.pollingClient.v1.timelines.home.list({
-      sinceId: active.cursor.statusSinceId,
-      limit: 20,
-    }),
-    active.pollingClient.v1.notifications.list({
-      sinceId: active.cursor.notificationSinceId,
-      limit: 20,
-      types: [...NOTIFICATION_TYPES],
-    }),
+    withRateLimit(serverUrl, () =>
+      client.v1.timelines.home.list({
+        sinceId: active.cursor.statusSinceId,
+        limit: 20,
+      }),
+    ),
+    withRateLimit(serverUrl, () =>
+      client.v1.notifications.list({
+        sinceId: active.cursor.notificationSinceId,
+        limit: 20,
+        types: [...NOTIFICATION_TYPES],
+      }),
+    ),
   ]);
 
   const statusSinceId = maxMastodonId(statuses.map((status) => status.id));
@@ -237,17 +237,14 @@ async function pollUserStream(active: ActiveSubscription): Promise<void> {
 }
 
 async function pollPublicStream(active: ActiveSubscription): Promise<void> {
-  if (!active.pollingClient) {
-    active.pollingClient = createRestAPIClient({
-      url: active.params.serverUrl,
-      accessToken: active.params.accessToken,
-    });
-  }
+  const client = getRestClient(active.params.serverUrl, active.params.accessToken);
 
-  const statuses = await active.pollingClient.v1.timelines.public.list({
-    sinceId: active.cursor.statusSinceId,
-    limit: 20,
-  });
+  const statuses = await withRateLimit(active.params.serverUrl, () =>
+    client.v1.timelines.public.list({
+      sinceId: active.cursor.statusSinceId,
+      limit: 20,
+    }),
+  );
 
   const statusSinceId = maxMastodonId(statuses.map((status) => status.id));
   if (statusSinceId) {

--- a/src/main/timeline.ts
+++ b/src/main/timeline.ts
@@ -1,5 +1,5 @@
-import { createRestAPIClient } from 'masto';
 import type { TimelineType, Post, PostVisibility } from '../shared/types.ts';
+import { getRestClient, withRateLimit } from './apiClient.ts';
 
 export async function fetchTimeline(
   serverUrl: string,
@@ -7,24 +7,22 @@ export async function fetchTimeline(
   type: TimelineType,
   maxId?: string,
 ): Promise<Post[]> {
-  const client = createRestAPIClient({ url: serverUrl, accessToken });
+  const client = getRestClient(serverUrl, accessToken);
 
   const params = { maxId, limit: 20 };
 
-  let statuses;
-  switch (type) {
-    case 'home':
-      statuses = await client.v1.timelines.home.list(params);
-      break;
-    case 'public':
-      statuses = await client.v1.timelines.public.list(params);
-      break;
-    case 'favourites':
-      statuses = await client.v1.favourites.list(params);
-      break;
-    case 'notifications':
-      return [];
-  }
+  const statuses = await withRateLimit(serverUrl, async () => {
+    switch (type) {
+      case 'home':
+        return client.v1.timelines.home.list(params);
+      case 'public':
+        return client.v1.timelines.public.list(params);
+      case 'favourites':
+        return client.v1.favourites.list(params);
+      case 'notifications':
+        return [];
+    }
+  });
 
   return statuses.map((status) => {
     // If this is a reblog, use the original post's content


### PR DESCRIPTION
## Summary
- サーバーURL+アクセストークン単位でREST APIクライアントをキャッシュする `apiClient.ts` を新設
- トークンバケット方式によるサーバー単位のレート制限（300リクエスト/5分）を実装
- `timeline.ts`, `statuses.ts`, `notifications.ts`, `streaming.ts` を新しい共有クライアントに移行

Closes #54

## Test plan
- [ ] タイムライン取得が正常に動作することを確認
- [ ] 投稿・ふぁぼ・ブースト・ブックマーク操作が正常に動作することを確認
- [ ] 通知取得が正常に動作することを確認
- [ ] ストリーミング接続・ポーリングフォールバックが正常に動作することを確認
- [ ] 短時間の大量リクエスト時にレート制限が適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)