### PR TITLE
feat: Mastodon APIコールに流量制御を導入

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   unbookmarkStatus,
 } from './statuses.ts';
 import { createMainWindowOptions, restoreMaximizeState, saveWindowState } from './windowState.ts';
+import { rateLimitedCall } from './rateLimiter.ts';
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({
@@ -96,13 +97,17 @@ function registerIpcHandlers(): void {
   );
 
   ipcMain.handle(IpcChannels.TimelineFetch, async (_event, params: TimelineFetchParams) => {
-    return fetchTimeline(params.serverUrl, params.accessToken, params.type, params.maxId);
+    return rateLimitedCall(() =>
+      fetchTimeline(params.serverUrl, params.accessToken, params.type, params.maxId),
+    );
   });
 
   ipcMain.handle(
     IpcChannels.NotificationsFetch,
     async (_event, params: NotificationFetchParams) => {
-      return fetchNotifications(params.serverUrl, params.accessToken, params.maxId);
+      return rateLimitedCall(() =>
+        fetchNotifications(params.serverUrl, params.accessToken, params.maxId),
+      );
     },
   );
 
@@ -115,47 +120,63 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IpcChannels.StatusesCreate, async (_event, params: StatusCreateParams) => {
-    await createStatus(
-      params.serverUrl,
-      params.accessToken,
-      params.status,
-      params.visibility,
-      params.mediaIds,
+    await rateLimitedCall(() =>
+      createStatus(
+        params.serverUrl,
+        params.accessToken,
+        params.status,
+        params.visibility,
+        params.mediaIds,
+      ),
     );
   });
 
   ipcMain.handle(IpcChannels.MediaUpload, async (_event, params: MediaUploadParams) => {
-    return uploadMedia(
-      params.serverUrl,
-      params.accessToken,
-      params.fileName,
-      params.mimeType,
-      params.data,
+    return rateLimitedCall(() =>
+      uploadMedia(
+        params.serverUrl,
+        params.accessToken,
+        params.fileName,
+        params.mimeType,
+        params.data,
+      ),
     );
   });
 
   ipcMain.handle(IpcChannels.StatusFavourite, async (_event, params: StatusActionParams) => {
-    await favouriteStatus(params.serverUrl, params.accessToken, params.statusId);
+    await rateLimitedCall(() =>
+      favouriteStatus(params.serverUrl, params.accessToken, params.statusId),
+    );
   });
 
   ipcMain.handle(IpcChannels.StatusUnfavourite, async (_event, params: StatusActionParams) => {
-    await unfavouriteStatus(params.serverUrl, params.accessToken, params.statusId);
+    await rateLimitedCall(() =>
+      unfavouriteStatus(params.serverUrl, params.accessToken, params.statusId),
+    );
   });
 
   ipcMain.handle(IpcChannels.StatusReblog, async (_event, params: StatusActionParams) => {
-    await reblogStatus(params.serverUrl, params.accessToken, params.statusId);
+    await rateLimitedCall(() =>
+      reblogStatus(params.serverUrl, params.accessToken, params.statusId),
+    );
   });
 
   ipcMain.handle(IpcChannels.StatusUnreblog, async (_event, params: StatusActionParams) => {
-    await unreblogStatus(params.serverUrl, params.accessToken, params.statusId);
+    await rateLimitedCall(() =>
+      unreblogStatus(params.serverUrl, params.accessToken, params.statusId),
+    );
   });
 
   ipcMain.handle(IpcChannels.StatusBookmark, async (_event, params: StatusActionParams) => {
-    await bookmarkStatus(params.serverUrl, params.accessToken, params.statusId);
+    await rateLimitedCall(() =>
+      bookmarkStatus(params.serverUrl, params.accessToken, params.statusId),
+    );
   });
 
   ipcMain.handle(IpcChannels.StatusUnbookmark, async (_event, params: StatusActionParams) => {
-    await unbookmarkStatus(params.serverUrl, params.accessToken, params.statusId);
+    await rateLimitedCall(() =>
+      unbookmarkStatus(params.serverUrl, params.accessToken, params.statusId),
+    );
   });
 
   ipcMain.handle(IpcChannels.StreamSubscribe, async (event, params: StreamSubscribeParams) => {

--- a/src/main/rateLimiter.ts
+++ b/src/main/rateLimiter.ts
@@ -1,0 +1,63 @@
+/**
+ * Rate limiter for Mastodon API calls.
+ * Combines a semaphore (max concurrency) with a token bucket (max rate).
+ */
+
+const MAX_CONCURRENT = 4;
+const TOKENS_PER_SECOND = 2;
+const MAX_TOKENS = 300;
+
+let tokens = MAX_TOKENS;
+let lastRefill = Date.now();
+let activeCalls = 0;
+const waitQueue: Array<() => void> = [];
+
+function refillTokens(): void {
+  const now = Date.now();
+  const elapsed = (now - lastRefill) / 1000;
+  tokens = Math.min(MAX_TOKENS, tokens + elapsed * TOKENS_PER_SECOND);
+  lastRefill = now;
+}
+
+function tryAcquire(): boolean {
+  refillTokens();
+  if (activeCalls < MAX_CONCURRENT && tokens >= 1) {
+    activeCalls++;
+    tokens -= 1;
+    return true;
+  }
+  return false;
+}
+
+function release(): void {
+  activeCalls--;
+  processQueue();
+}
+
+function processQueue(): void {
+  while (waitQueue.length > 0 && tryAcquire()) {
+    const resolve = waitQueue.shift()!;
+    resolve();
+  }
+}
+
+function acquire(): Promise<void> {
+  if (tryAcquire()) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waitQueue.push(resolve);
+    // Schedule a retry for when tokens should refill
+    const waitMs = tokens < 1 ? ((1 - tokens) / TOKENS_PER_SECOND) * 1000 : 100;
+    setTimeout(() => processQueue(), Math.ceil(waitMs));
+  });
+}
+
+export async function rateLimitedCall<T>(fn: () => Promise<T>): Promise<T> {
+  await acquire();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}

--- a/src/main/streaming.ts
+++ b/src/main/streaming.ts
@@ -11,6 +11,7 @@ import type {
   StreamType,
 } from '../shared/types.ts';
 import { IpcChannels } from '../shared/ipc.ts';
+import { rateLimitedCall } from './rateLimiter.ts';
 
 const POLLING_INTERVAL_MS = 60_000;
 const STREAM_RETRY_INTERVAL_MS = 30_000;
@@ -163,7 +164,7 @@ function maxMastodonId(ids: string[]): string | undefined {
 
 async function getStreamingApiUrl(serverUrl: string, accessToken: string): Promise<string> {
   const rest = createRestAPIClient({ url: serverUrl, accessToken });
-  const instance = await rest.v2.instance.fetch();
+  const instance = await rateLimitedCall(() => rest.v2.instance.fetch());
   return instance.configuration.urls.streaming;
 }
 
@@ -214,15 +215,19 @@ async function pollUserStream(active: ActiveSubscription): Promise<void> {
   }
 
   const [statuses, notifications] = await Promise.all([
-    active.pollingClient.v1.timelines.home.list({
-      sinceId: active.cursor.statusSinceId,
-      limit: 20,
-    }),
-    active.pollingClient.v1.notifications.list({
-      sinceId: active.cursor.notificationSinceId,
-      limit: 20,
-      types: [...NOTIFICATION_TYPES],
-    }),
+    rateLimitedCall(async () =>
+      active.pollingClient!.v1.timelines.home.list({
+        sinceId: active.cursor.statusSinceId,
+        limit: 20,
+      }),
+    ),
+    rateLimitedCall(async () =>
+      active.pollingClient!.v1.notifications.list({
+        sinceId: active.cursor.notificationSinceId,
+        limit: 20,
+        types: [...NOTIFICATION_TYPES],
+      }),
+    ),
   ]);
 
   const statusSinceId = maxMastodonId(statuses.map((status) => status.id));
@@ -264,10 +269,12 @@ async function pollPublicStream(active: ActiveSubscription): Promise<void> {
     });
   }
 
-  const statuses = await active.pollingClient.v1.timelines.public.list({
-    sinceId: active.cursor.statusSinceId,
-    limit: 20,
-  });
+  const statuses = await rateLimitedCall(async () =>
+    active.pollingClient!.v1.timelines.public.list({
+      sinceId: active.cursor.statusSinceId,
+      limit: 20,
+    }),
+  );
 
   const statusSinceId = maxMastodonId(statuses.map((status) => status.id));
   if (statusSinceId) {


### PR DESCRIPTION
## Summary
- Mastodon APIへの過剰なリクエストを防ぐため、メインプロセスのAPIコールに流量制御を導入
- セマフォ（最大並行数4）とトークンバケット（2 tokens/sec、バースト上限300）を組み合わせた `rateLimitedCall` を新規実装
- IPC handler 10個（TimelineFetch, NotificationsFetch, StatusesCreate, MediaUpload, StatusFavourite/Unfavourite, StatusReblog/Unreblog, StatusBookmark/Unbookmark）をラップ
- ポーリングフォールバック内のREST APIコール（pollUserStream, pollPublicStream, getStreamingApiUrl）もラップ

## Test plan
- [x] `bun run lint` がパスすること
- [x] `bun run typecheck` がパスすること
- [x] `bun run build` が成功すること
- [x] タイムライン取得・通知取得が正常に動作すること
- [x] 投稿・メディアアップロードが正常に動作すること
- [x] ふぁぼ・ブースト・ブックマーク操作が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)