### PR TITLE
feat: add always-expanded timeline display option

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -9,6 +9,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   postFontSize: 14,
   uiFontSize: 14,
   compactFontSize: 12,
+  disableCompactDisplay: false,
 };
 
 function getSettingsFilePath(): string {

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   postFontSize: 14,
   uiFontSize: 14,
   compactFontSize: 12,
+  disableCompactDisplay: false,
 };
 
 export interface SettingsContextValue {

--- a/src/renderer/pages/SettingsPage.tsx
+++ b/src/renderer/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Flex, InputNumber, Typography, App } from 'antd';
+import { Button, Flex, InputNumber, Switch, Typography, App } from 'antd';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import type { AppSettings } from '../../shared/types.ts';
@@ -10,6 +10,9 @@ const { Title, Text } = Typography;
 interface SettingsPageProps {
   onBack: () => void;
 }
+
+type NumericSettingKey = Exclude<keyof AppSettings, 'disableCompactDisplay'>;
+type BooleanSettingKey = Extract<keyof AppSettings, 'disableCompactDisplay'>;
 
 const PageContainer = styled.div`
   height: 100vh;
@@ -78,10 +81,14 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
     setDraft({ ...DEFAULT_SETTINGS });
   };
 
-  const update = (key: keyof AppSettings, value: number | null): void => {
+  const updateNumber = (key: NumericSettingKey, value: number | null): void => {
     if (value !== null) {
       setDraft((prev) => ({ ...prev, [key]: value }));
     }
+  };
+
+  const updateBoolean = (key: BooleanSettingKey, value: boolean): void => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
   };
 
   return (
@@ -100,7 +107,7 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
             min={16}
             max={128}
             value={draft.avatarSize}
-            onChange={(v) => update('avatarSize', v)}
+            onChange={(v) => updateNumber('avatarSize', v)}
             style={{ marginTop: 8 }}
           />
         </SettingRow>
@@ -112,7 +119,7 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
             min={12}
             max={64}
             value={draft.boostAvatarSize}
-            onChange={(v) => update('boostAvatarSize', v)}
+            onChange={(v) => updateNumber('boostAvatarSize', v)}
             style={{ marginTop: 8 }}
           />
         </SettingRow>
@@ -124,7 +131,7 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
             min={8}
             max={32}
             value={draft.postFontSize}
-            onChange={(v) => update('postFontSize', v)}
+            onChange={(v) => updateNumber('postFontSize', v)}
             style={{ marginTop: 8 }}
           />
         </SettingRow>
@@ -136,7 +143,7 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
             min={8}
             max={32}
             value={draft.uiFontSize}
-            onChange={(v) => update('uiFontSize', v)}
+            onChange={(v) => updateNumber('uiFontSize', v)}
             style={{ marginTop: 8 }}
           />
         </SettingRow>
@@ -148,7 +155,17 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
             min={8}
             max={24}
             value={draft.compactFontSize}
-            onChange={(v) => update('compactFontSize', v)}
+            onChange={(v) => updateNumber('compactFontSize', v)}
+            style={{ marginTop: 8 }}
+          />
+        </SettingRow>
+
+        <SettingRow>
+          <Text strong>常時拡大表示（縮小表示を使用しない）</Text>
+          <br />
+          <Switch
+            checked={draft.disableCompactDisplay}
+            onChange={(checked) => updateBoolean('disableCompactDisplay', checked)}
             style={{ marginTop: 8 }}
           />
         </SettingRow>

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -29,6 +29,7 @@ import { NotificationItem } from '../components/NotificationItem.tsx';
 import { Composer } from '../components/Composer.tsx';
 import { CompactPostItem } from '../components/CompactPostItem.tsx';
 import { PaneContainer } from '../components/PaneContainer.tsx';
+import { useSettings } from '../hooks/useSettings.ts';
 
 const { Text } = Typography;
 
@@ -166,6 +167,7 @@ function TimelineTabContent({
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [expandedPostId, setExpandedPostId] = useState<string | null>(null);
+  const { settings } = useSettings();
   const listRef = useRef<HTMLDivElement>(null);
   const postsRef = useRef(posts);
   postsRef.current = posts;
@@ -292,14 +294,14 @@ function TimelineTabContent({
   return (
     <TimelineList ref={listRef}>
       {posts.map((post) =>
-        expandedPostId === post.id ? (
+        settings.disableCompactDisplay || expandedPostId === post.id ? (
           <PostItem
             key={post.id}
             post={post}
             serverUrl={account.serverUrl}
             accessToken={account.accessToken}
             onReply={(targetPost) => onReply(tab, targetPost)}
-            onCollapse={() => setExpandedPostId(null)}
+            onCollapse={settings.disableCompactDisplay ? undefined : () => setExpandedPostId(null)}
           />
         ) : (
           <CompactPostItem key={post.id} post={post} onClick={() => setExpandedPostId(post.id)} />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -315,4 +315,5 @@ export interface AppSettings {
   postFontSize: number;
   uiFontSize: number;
   compactFontSize: number;
+  disableCompactDisplay: boolean;
 }


### PR DESCRIPTION
### Motivation
- Implement Issue #80 by adding a user-configurable option to disable the compact (tight) timeline rows so users can always see expanded posts.

### Description
- Add `disableCompactDisplay: boolean` to the `AppSettings` type in `src/shared/types.ts` so the setting is persisted and typed.
- Add the default value to both main-process defaults in `src/main/settings.ts` and renderer defaults in `src/renderer/hooks/useSettings.ts` as `false`.
- Expose a new `Switch` in the Settings UI (`src/renderer/pages/SettingsPage.tsx`) labeled `常時拡大表示（縮小表示を使用しない）`, and split numeric/boolean update helpers for type safety when updating the draft settings.
- Update timeline rendering (`src/renderer/pages/TimelinePage.tsx`) to render `PostItem` for every post when `disableCompactDisplay` is enabled and to disable collapse-on-avatar behavior in that mode.

### Testing
- Ran `bun run format` which completed successfully.
- Ran `bun run lint` which initially failed due to missing dev dependencies, then after `bun install` lint completed successfully.
- Ran `bun run typecheck` (`tsc -b`) which completed without errors.
- Ran `bun test` which exited successfully but reported no test files were found in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7a27a9bb0832b8c4a5fe9af7a3698)