### PR TITLE
feat: 拡大表示をMastodon公式ライクにする設定を追加

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -10,6 +10,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   uiFontSize: 14,
   compactFontSize: 12,
   disableCompactDisplay: false,
+  mastodonLikeExpandedDisplay: false,
 };
 
 function getSettingsFilePath(): string {

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -76,10 +76,11 @@ const Content = styled.div`
   min-width: 0;
 `;
 
-const HeaderLine = styled.div`
+const HeaderLine = styled.div<{ $mastodonLike: boolean }>`
   display: flex;
-  gap: 8px;
-  align-items: baseline;
+  flex-direction: ${(props) => (props.$mastodonLike ? 'column' : 'row')};
+  gap: ${(props) => (props.$mastodonLike ? '0' : '8px')};
+  align-items: ${(props) => (props.$mastodonLike ? 'flex-start' : 'baseline')};
   margin-bottom: 4px;
 `;
 
@@ -307,16 +308,28 @@ export function PostItem({
         )}
       </AvatarColumn>
       <Content>
-        <HeaderLine>
+        <HeaderLine $mastodonLike={settings.mastodonLikeExpandedDisplay}>
+          {settings.mastodonLikeExpandedDisplay && (
+            <DisplayName
+              $fontSize={settings.uiFontSize}
+              dangerouslySetInnerHTML={{
+                __html: sanitizeContent(
+                  replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
+                ),
+              }}
+            />
+          )}
           <Acct $fontSize={settings.uiFontSize}>@{post.account.acct}</Acct>
-          <DisplayName
-            $fontSize={settings.uiFontSize}
-            dangerouslySetInnerHTML={{
-              __html: sanitizeContent(
-                replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
-              ),
-            }}
-          />
+          {!settings.mastodonLikeExpandedDisplay && (
+            <DisplayName
+              $fontSize={settings.uiFontSize}
+              dangerouslySetInnerHTML={{
+                __html: sanitizeContent(
+                  replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
+                ),
+              }}
+            />
+          )}
         </HeaderLine>
         {hasContentWarning && (
           <ContentWarning $fontSize={settings.postFontSize} onClick={() => setExpanded(!expanded)}>

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -8,6 +8,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   uiFontSize: 14,
   compactFontSize: 12,
   disableCompactDisplay: false,
+  mastodonLikeExpandedDisplay: false,
 };
 
 export interface SettingsContextValue {

--- a/src/renderer/pages/SettingsPage.tsx
+++ b/src/renderer/pages/SettingsPage.tsx
@@ -11,8 +11,14 @@ interface SettingsPageProps {
   onBack: () => void;
 }
 
-type NumericSettingKey = Exclude<keyof AppSettings, 'disableCompactDisplay'>;
-type BooleanSettingKey = Extract<keyof AppSettings, 'disableCompactDisplay'>;
+type NumericSettingKey = Exclude<
+  keyof AppSettings,
+  'disableCompactDisplay' | 'mastodonLikeExpandedDisplay'
+>;
+type BooleanSettingKey = Extract<
+  keyof AppSettings,
+  'disableCompactDisplay' | 'mastodonLikeExpandedDisplay'
+>;
 
 const PageContainer = styled.div`
   height: 100vh;
@@ -170,6 +176,16 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
           />
         </SettingRow>
 
+        <SettingRow>
+          <Text strong>拡大表示をMastodon公式ライクにする</Text>
+          <br />
+          <Switch
+            checked={draft.mastodonLikeExpandedDisplay}
+            onChange={(checked) => updateBoolean('mastodonLikeExpandedDisplay', checked)}
+            style={{ marginTop: 8 }}
+          />
+        </SettingRow>
+
         <Flex gap={12}>
           <Button type="primary" onClick={handleSave}>
             保存
@@ -189,8 +205,17 @@ export function SettingsPage({ onBack }: SettingsPageProps): React.JSX.Element {
               </div>
             </div>
             <div>
-              <div style={{ fontSize: draft.uiFontSize, fontWeight: 600 }}>@user</div>
-              <div style={{ fontSize: draft.uiFontSize, color: '#8c8c8c' }}>Display Name</div>
+              {draft.mastodonLikeExpandedDisplay ? (
+                <>
+                  <div style={{ fontSize: draft.uiFontSize, color: '#8c8c8c' }}>Display Name</div>
+                  <div style={{ fontSize: draft.uiFontSize, fontWeight: 600 }}>@user</div>
+                </>
+              ) : (
+                <>
+                  <div style={{ fontSize: draft.uiFontSize, fontWeight: 600 }}>@user</div>
+                  <div style={{ fontSize: draft.uiFontSize, color: '#8c8c8c' }}>Display Name</div>
+                </>
+              )}
               <div style={{ fontSize: draft.postFontSize, lineHeight: 1.6, marginTop: 4 }}>
                 これはプレビュー用のサンプル投稿です。文字サイズやアイコンの大きさを確認できます。
               </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -316,4 +316,5 @@ export interface AppSettings {
   uiFontSize: number;
   compactFontSize: number;
   disableCompactDisplay: boolean;
+  mastodonLikeExpandedDisplay: boolean;
 }


### PR DESCRIPTION
### Motivation
- Issue #83 に対応し、拡大表示時のアカウントヘッダーを Mastodon 公式ライク（表示名と acct の2段表示）に切り替えられるオプションを追加するための変更です。\
- 絶対時刻表示は既存のまま維持します。\

### Description
- `AppSettings` に `mastodonLikeExpandedDisplay: boolean` を追加して設定を拡張しました (`src/shared/types.ts`)。\
- メイン/レンダラー双方のデフォルト設定に `mastodonLikeExpandedDisplay: false` を追加しました (`src/main/settings.ts`, `src/renderer/hooks/useSettings.ts`)。\
- 設定画面に「拡大表示をMastodon公式ライクにする」スイッチを追加し、プレビューも ON/OFF に応じて反映するようにしました (`src/renderer/pages/SettingsPage.tsx`)。\
- `PostItem` のヘッダー表示を設定に応じて切り替えるようにし、ON の場合は縦並びで `Display Name`→`@acct`、OFF の場合は従来の横並び表示を維持する実装を行いました (`src/renderer/components/PostItem.tsx`)。\

### Testing
- 実行したコマンド: `bun run format`（成功）、`bun install`（成功）、`bun run lint`（成功）、`bun run typecheck`（成功）。\
- `bun run dev` はこの環境で `libatk-1.0.so.0` が不足しているため Electron の起動に失敗し UI の実機確認は取得できませんでした（環境依存のライブラリ欠如による実行エラー）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24d6e1ee0832b928748367fc73c1d)