### PR TITLE
fix: strengthen streaming connection detection and auto-reconnect

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,13 @@
-import { app, BrowserWindow, ipcMain, nativeImage, Notification, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  nativeImage,
+  Notification,
+  shell,
+  powerMonitor,
+  net,
+} from 'electron';
 import path from 'node:path';
 import { IpcChannels } from '../shared/ipc.ts';
 import type {
@@ -21,7 +30,12 @@ import { fetchNotifications } from './notifications.ts';
 import { listTabs, saveTabs } from './tabs.ts';
 import { loadSettings, saveSettings } from './settings.ts';
 import { loadPaneLayout, savePaneLayout } from './panes.ts';
-import { subscribeStream, unsubscribeStream, unsubscribeAllStreams } from './streaming.ts';
+import {
+  subscribeStream,
+  unsubscribeStream,
+  unsubscribeAllStreams,
+  restartAllStreams,
+} from './streaming.ts';
 import {
   createStatus,
   uploadMedia,
@@ -233,6 +247,14 @@ app.whenReady().then(() => {
   console.log('Registered IPC handlers');
   createWindow();
   console.log('App is ready');
+
+  powerMonitor.on('resume', () => {
+    restartAllStreams('restarting after system resume');
+  });
+
+  net.on('online', () => {
+    restartAllStreams('restarting after network online');
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/streaming.ts
+++ b/src/main/streaming.ts
@@ -15,6 +15,8 @@ import { rateLimitedCall } from './rateLimiter.ts';
 
 const POLLING_INTERVAL_MS = 60_000;
 const STREAM_RETRY_INTERVAL_MS = 30_000;
+const STREAM_HEALTHCHECK_INTERVAL_MS = 15_000;
+const STREAM_STALE_THRESHOLD_MS = 45_000;
 const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
 
 interface StreamingHandles {
@@ -32,6 +34,8 @@ interface ActiveSubscription {
   webContents: WebContents;
   abortController: AbortController;
   streaming?: StreamingHandles;
+  lastStreamActivityAt?: number;
+  streamHealthcheckTimer?: ReturnType<typeof setInterval>;
   retryTimer?: ReturnType<typeof setTimeout>;
   pollingTimer?: ReturnType<typeof setInterval>;
   pollingClient?: mastodon.rest.Client;
@@ -183,11 +187,35 @@ function subscribe(
 }
 
 function cleanupStreaming(active: ActiveSubscription): void {
+  if (active.streamHealthcheckTimer) {
+    clearInterval(active.streamHealthcheckTimer);
+    active.streamHealthcheckTimer = undefined;
+  }
+  active.lastStreamActivityAt = undefined;
+
   if (!active.streaming) return;
 
   active.streaming.subscription.unsubscribe();
   active.streaming.client.close();
   active.streaming = undefined;
+}
+
+function startStreamingHealthcheck(active: ActiveSubscription): void {
+  if (!isActive(active) || !active.streaming || active.streamHealthcheckTimer) {
+    return;
+  }
+
+  active.streamHealthcheckTimer = setInterval(() => {
+    if (!isActive(active) || !active.streaming) {
+      return;
+    }
+
+    const now = Date.now();
+    const lastActivityAt = active.lastStreamActivityAt ?? now;
+    if (now - lastActivityAt > STREAM_STALE_THRESHOLD_MS) {
+      handleStreamingFailure(active, 'timed out waiting for stream events');
+    }
+  }, STREAM_HEALTHCHECK_INTERVAL_MS);
 }
 
 function scheduleStreamingRetry(active: ActiveSubscription): void {
@@ -368,12 +396,14 @@ async function startStreaming(active: ActiveSubscription): Promise<void> {
       subscription,
       client: streamingClient,
     };
+    active.lastStreamActivityAt = Date.now();
 
     if (active.retryTimer) {
       clearTimeout(active.retryTimer);
       active.retryTimer = undefined;
     }
     stopPolling(active);
+    startStreamingHealthcheck(active);
     sendConnectionStatus(active, 'streaming');
 
     for await (const event of subscription) {
@@ -382,6 +412,7 @@ async function startStreaming(active: ActiveSubscription): Promise<void> {
       }
 
       let eventData: StreamEventData | null = null;
+      active.lastStreamActivityAt = Date.now();
 
       switch (event.event) {
         case 'update':
@@ -460,5 +491,15 @@ export function unsubscribeStream(subscriptionId: string): void {
 export function unsubscribeAllStreams(): void {
   for (const subscriptionId of activeSubscriptions.keys()) {
     unsubscribeStream(subscriptionId);
+  }
+}
+
+export function restartAllStreams(reason: string): void {
+  for (const active of activeSubscriptions.values()) {
+    if (!isActive(active)) {
+      continue;
+    }
+
+    handleStreamingFailure(active, reason);
   }
 }


### PR DESCRIPTION
### Motivation
- Issue #85 対応として、スリープ復帰やネットワーク構成変更時に実際は切断しているのにストリーミングが接続中判定のままになる問題を解消するための変更です。

### Description
- `src/main/streaming.ts` にストリームのヘルスチェック用の定数と `ActiveSubscription` の `lastStreamActivityAt` / `streamHealthcheckTimer` を追加し、一定時間イベントが届かない場合にタイムアウト判定して再接続処理へフォールバックするようにしました。
- ストリーミング開始時にヘルスチェックタイマーを起動し、受信イベントごとに `lastStreamActivityAt` を更新することでハートビート停滞を検知するようにしました。`
- 切断時にヘルスチェックタイマーをクリアするよう `cleanupStreaming` を拡張し、再利用可能な再起動トリガー `restartAllStreams(reason)` を追加しました（両方は `src/main/streaming.ts` の変更）。
- Electron メインプロセス側の `src/main/index.ts` で `powerMonitor.on('resume')` と `net.on('online')` を監視して `restartAllStreams` を呼び出すことで、スリープ復帰・ネットワーク復帰時に全ストリームの再接続をトリガーするようにしました。

### Testing
- `bun run format:check` を実行してコードフォーマットは問題ないことを確認しました（成功）。
- `bun run lint` を実行して ESLint チェックを通過することを確認しました（依存をインストール後に成功）。
- `bun test` を実行しましたが、該当するテストファイルが無いためテストは実行されませんでした（実行は成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b266c4ce84832b8f9da44461440b7f)