### PR TITLE
feat: Ctrl-R でTL表示をクリアして再取得する機能を追加

### DIFF
--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -198,6 +198,22 @@ function TimelineTabContent({
     }
   }, [account, tab.timelineType, message]);
 
+  const handleRefresh = useCallback(() => {
+    setPosts([]);
+    void loadTimeline();
+  }, [loadTimeline]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.ctrlKey && e.key === 'r') {
+        e.preventDefault();
+        handleRefresh();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleRefresh]);
+
   const loadMore = useCallback(async () => {
     if (!account || loadingMoreRef.current || !hasMoreRef.current) return;
     const currentPosts = postsRef.current;


### PR DESCRIPTION
## Summary
- `TimelineTabContent` に `handleRefresh` を追加し、postsをクリアしてからタイムラインを再取得する
- `window` の `keydown` イベントを監視し、Ctrl-R が押されたら `handleRefresh` を呼び出す
- Ctrl-R のデフォルト動作（ページリロード）を `e.preventDefault()` で抑制する

## Related Issue
closes #87

## Test plan
- [ ] TL表示ペインで Ctrl-R を押すと、表示中のポストが消えてスピナーが表示され、その後最新のポストが取得される
- [ ] 複数ペインがある場合、すべてのTLペインがリフレッシュされる
- [ ] Ctrl-R を押してもアプリがリロードされないことを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)