### PR TITLE
feat: account timeline profile actions

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { IpcChannels } from '../shared/ipc.ts';
 import type {
   AppSettings,
+  AccountProfileFetchParams,
+  AccountRelationshipParams,
   NotificationFetchParams,
   OAuthExchangeTokenParams,
   PaneLayout,
@@ -16,7 +18,13 @@ import type {
 } from '../shared/types.ts';
 import { startLogin, exchangeToken } from './oauth.ts';
 import { listAccounts, addAccount, removeAccount } from './accounts.ts';
-import { fetchTimeline } from './timeline.ts';
+import {
+  fetchAccountProfile,
+  fetchAccountRelationship,
+  fetchTimeline,
+  followAccount,
+  unfollowAccount,
+} from './timeline.ts';
 import { fetchNotifications } from './notifications.ts';
 import { listTabs, saveTabs } from './tabs.ts';
 import { loadSettings, saveSettings } from './settings.ts';
@@ -34,6 +42,15 @@ import {
 } from './statuses.ts';
 import { createMainWindowOptions, restoreMaximizeState, saveWindowState } from './windowState.ts';
 import { rateLimitedCall } from './rateLimiter.ts';
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({
@@ -56,8 +73,20 @@ function createWindow(): void {
 
   // Open external links in the default browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isHttpUrl(url)) {
+      shell.openExternal(url);
+    }
     return { action: 'deny' };
+  });
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    const currentUrl = mainWindow.webContents.getURL();
+    if (url === currentUrl) {
+      return;
+    }
+    event.preventDefault();
+    if (isHttpUrl(url)) {
+      shell.openExternal(url);
+    }
   });
 
   if (process.env['ELECTRON_RENDERER_URL']) {
@@ -99,7 +128,43 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(IpcChannels.TimelineFetch, async (_event, params: TimelineFetchParams) => {
     return rateLimitedCall(() =>
-      fetchTimeline(params.serverUrl, params.accessToken, params.type, params.maxId),
+      fetchTimeline(
+        params.serverUrl,
+        params.accessToken,
+        params.type,
+        params.accountId,
+        params.maxId,
+      ),
+    );
+  });
+
+  ipcMain.handle(
+    IpcChannels.AccountProfileFetch,
+    async (_event, params: AccountProfileFetchParams) => {
+      return rateLimitedCall(() =>
+        fetchAccountProfile(params.serverUrl, params.accessToken, params.accountId),
+      );
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.AccountRelationshipFetch,
+    async (_event, params: AccountRelationshipParams) => {
+      return rateLimitedCall(() =>
+        fetchAccountRelationship(params.serverUrl, params.accessToken, params.accountId),
+      );
+    },
+  );
+
+  ipcMain.handle(IpcChannels.AccountFollow, async (_event, params: AccountRelationshipParams) => {
+    return rateLimitedCall(() =>
+      followAccount(params.serverUrl, params.accessToken, params.accountId),
+    );
+  });
+
+  ipcMain.handle(IpcChannels.AccountUnfollow, async (_event, params: AccountRelationshipParams) => {
+    return rateLimitedCall(() =>
+      unfollowAccount(params.serverUrl, params.accessToken, params.accountId),
     );
   });
 

--- a/src/main/mastodonConverters.ts
+++ b/src/main/mastodonConverters.ts
@@ -1,0 +1,116 @@
+import type { mastodon } from 'masto';
+import type {
+  AccountProfile,
+  AccountProfileField,
+  MastoNotification,
+  Post,
+  PostVisibility,
+} from '../shared/types.ts';
+
+const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
+
+export function isSupportedNotificationType(
+  type: string,
+): type is (typeof NOTIFICATION_TYPES)[number] {
+  return NOTIFICATION_TYPES.includes(type as (typeof NOTIFICATION_TYPES)[number]);
+}
+
+function convertEmojis(emojis: mastodon.v1.CustomEmoji[]): Post['emojis'] {
+  return emojis.map((emoji) => ({
+    shortcode: emoji.shortcode,
+    url: emoji.url,
+    staticUrl: emoji.staticUrl,
+  }));
+}
+
+function convertFields(fields: mastodon.v1.AccountField[]): AccountProfileField[] {
+  return fields.map((field) => ({
+    name: field.name,
+    value: field.value,
+    verifiedAt: field.verifiedAt ?? null,
+  }));
+}
+
+export function convertAccount(account: mastodon.v1.Account): AccountProfile {
+  return {
+    id: account.id,
+    acct: account.acct,
+    username: account.username,
+    displayName: account.displayName,
+    note: account.note,
+    avatarUrl: account.avatar,
+    headerUrl: account.header,
+    url: account.url,
+    followersCount: account.followersCount,
+    followingCount: account.followingCount,
+    statusesCount: account.statusesCount,
+    following: false,
+    requested: false,
+    emojis: convertEmojis(account.emojis),
+    fields: convertFields(account.fields),
+  };
+}
+
+export function convertStatus(status: mastodon.v1.Status): Post {
+  const original = status.reblog ?? status;
+  const rebloggedBy = status.reblog
+    ? {
+        id: status.account.id,
+        acct: status.account.acct,
+        displayName: status.account.displayName,
+        avatarUrl: status.account.avatar,
+      }
+    : undefined;
+
+  return {
+    id: status.id,
+    content: original.content,
+    createdAt: original.createdAt,
+    spoilerText: original.spoilerText,
+    sensitive: original.sensitive,
+    url: original.url ?? null,
+    visibility: original.visibility as PostVisibility,
+    account: {
+      id: original.account.id,
+      acct: original.account.acct,
+      displayName: original.account.displayName,
+      avatarUrl: original.account.avatar,
+      emojis: convertEmojis(original.account.emojis),
+    },
+    mediaAttachments: original.mediaAttachments
+      .filter((media) => media.url != null && media.previewUrl != null)
+      .map((media) => ({
+        id: media.id,
+        type: media.type,
+        url: media.url!,
+        previewUrl: media.previewUrl!,
+        description: media.description ?? null,
+      })),
+    emojis: convertEmojis(original.emojis),
+    favourited: status.favourited ?? false,
+    reblogged: status.reblogged ?? false,
+    bookmarked: status.bookmarked ?? false,
+    rebloggedBy,
+  };
+}
+
+export function convertNotification(notification: mastodon.v1.Notification): MastoNotification {
+  const result: MastoNotification = {
+    id: notification.id,
+    type: notification.type as MastoNotification['type'],
+    createdAt: notification.createdAt,
+    account: {
+      id: notification.account.id,
+      acct: notification.account.acct,
+      displayName: notification.account.displayName,
+      avatarUrl: notification.account.avatar,
+      emojis: convertEmojis(notification.account.emojis),
+    },
+  };
+
+  if (notification.status) {
+    result.status = convertStatus(notification.status);
+  }
+
+  return result;
+}

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -1,7 +1,6 @@
 import { createRestAPIClient } from 'masto';
-import type { MastoNotification, Post, PostVisibility } from '../shared/types.ts';
-
-const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
+import type { MastoNotification } from '../shared/types.ts';
+import { convertNotification, isSupportedNotificationType } from './mastodonConverters.ts';
 
 export async function fetchNotifications(
   serverUrl: string,
@@ -13,69 +12,10 @@ export async function fetchNotifications(
   const notifications = await client.v1.notifications.list({
     maxId,
     limit: 20,
-    types: [...NOTIFICATION_TYPES],
+    types: ['follow', 'follow_request', 'favourite', 'reblog'],
   });
 
   return notifications
-    .filter((n) => NOTIFICATION_TYPES.includes(n.type as (typeof NOTIFICATION_TYPES)[number]))
-    .map((n) => {
-      const result: MastoNotification = {
-        id: n.id,
-        type: n.type as MastoNotification['type'],
-        createdAt: n.createdAt,
-        account: {
-          acct: n.account.acct,
-          displayName: n.account.displayName,
-          avatarUrl: n.account.avatar,
-          emojis: n.account.emojis.map((e) => ({
-            shortcode: e.shortcode,
-            url: e.url,
-            staticUrl: e.staticUrl,
-          })),
-        },
-      };
-
-      if (n.status) {
-        const original = n.status.reblog ?? n.status;
-        const status: Post = {
-          id: n.status.id,
-          content: original.content,
-          spoilerText: original.spoilerText,
-          sensitive: original.sensitive,
-          createdAt: original.createdAt,
-          url: original.url ?? null,
-          visibility: original.visibility as PostVisibility,
-          account: {
-            acct: original.account.acct,
-            displayName: original.account.displayName,
-            avatarUrl: original.account.avatar,
-            emojis: original.account.emojis.map((e) => ({
-              shortcode: e.shortcode,
-              url: e.url,
-              staticUrl: e.staticUrl,
-            })),
-          },
-          mediaAttachments: original.mediaAttachments
-            .filter((m) => m.url != null && m.previewUrl != null)
-            .map((m) => ({
-              id: m.id,
-              type: m.type,
-              url: m.url!,
-              previewUrl: m.previewUrl!,
-              description: m.description ?? null,
-            })),
-          emojis: original.emojis.map((emoji) => ({
-            shortcode: emoji.shortcode,
-            url: emoji.url,
-            staticUrl: emoji.staticUrl,
-          })),
-          favourited: n.status.favourited ?? false,
-          reblogged: n.status.reblogged ?? false,
-          bookmarked: n.status.bookmarked ?? false,
-        };
-        result.status = status;
-      }
-
-      return result;
-    });
+    .filter((notification) => isSupportedNotificationType(notification.type))
+    .map(convertNotification);
 }

--- a/src/main/streaming.ts
+++ b/src/main/streaming.ts
@@ -2,9 +2,6 @@ import { createRestAPIClient, createStreamingAPIClient } from 'masto';
 import type { mastodon } from 'masto';
 import type { WebContents } from 'electron';
 import type {
-  MastoNotification,
-  Post,
-  PostVisibility,
   StreamConnectionStatus,
   StreamEventData,
   StreamSubscribeParams,
@@ -12,10 +9,14 @@ import type {
 } from '../shared/types.ts';
 import { IpcChannels } from '../shared/ipc.ts';
 import { rateLimitedCall } from './rateLimiter.ts';
+import {
+  convertNotification,
+  convertStatus,
+  isSupportedNotificationType,
+} from './mastodonConverters.ts';
 
 const POLLING_INTERVAL_MS = 60_000;
 const STREAM_RETRY_INTERVAL_MS = 30_000;
-const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
 
 interface StreamingHandles {
   subscription: mastodon.streaming.Subscription;
@@ -39,84 +40,6 @@ interface ActiveSubscription {
 }
 
 const activeSubscriptions = new Map<string, ActiveSubscription>();
-
-function convertStatus(status: mastodon.v1.Status): Post {
-  const original = status.reblog ?? status;
-  const rebloggedBy = status.reblog
-    ? {
-        acct: status.account.acct,
-        displayName: status.account.displayName,
-        avatarUrl: status.account.avatar,
-        emojis: status.account.emojis.map((e) => ({
-          shortcode: e.shortcode,
-          url: e.url,
-          staticUrl: e.staticUrl,
-        })),
-      }
-    : undefined;
-
-  return {
-    id: status.id,
-    content: original.content,
-    createdAt: original.createdAt,
-    spoilerText: original.spoilerText,
-    sensitive: original.sensitive,
-    url: original.url ?? null,
-    visibility: original.visibility as PostVisibility,
-    account: {
-      acct: original.account.acct,
-      displayName: original.account.displayName,
-      avatarUrl: original.account.avatar,
-      emojis: original.account.emojis.map((e) => ({
-        shortcode: e.shortcode,
-        url: e.url,
-        staticUrl: e.staticUrl,
-      })),
-    },
-    mediaAttachments: original.mediaAttachments
-      .filter((m) => m.url != null && m.previewUrl != null)
-      .map((m) => ({
-        id: m.id,
-        type: m.type,
-        url: m.url!,
-        previewUrl: m.previewUrl!,
-        description: m.description ?? null,
-      })),
-    emojis: original.emojis.map((emoji) => ({
-      shortcode: emoji.shortcode,
-      url: emoji.url,
-      staticUrl: emoji.staticUrl,
-    })),
-    favourited: status.favourited ?? false,
-    reblogged: status.reblogged ?? false,
-    bookmarked: status.bookmarked ?? false,
-    rebloggedBy,
-  };
-}
-
-function convertNotification(n: mastodon.v1.Notification): MastoNotification {
-  const result: MastoNotification = {
-    id: n.id,
-    type: n.type as MastoNotification['type'],
-    createdAt: n.createdAt,
-    account: {
-      acct: n.account.acct,
-      displayName: n.account.displayName,
-      avatarUrl: n.account.avatar,
-      emojis: n.account.emojis.map((e) => ({
-        shortcode: e.shortcode,
-        url: e.url,
-        staticUrl: e.staticUrl,
-      })),
-    },
-  };
-
-  if (n.status) {
-    result.status = convertStatus(n.status);
-  }
-
-  return result;
-}
 
 function isActive(active: ActiveSubscription): boolean {
   return (
@@ -227,7 +150,7 @@ async function pollUserStream(active: ActiveSubscription): Promise<void> {
       active.pollingClient!.v1.notifications.list({
         sinceId: active.cursor.notificationSinceId,
         limit: 20,
-        types: [...NOTIFICATION_TYPES],
+        types: ['follow', 'follow_request', 'favourite', 'reblog'],
       }),
     ),
   ]);
@@ -251,7 +174,7 @@ async function pollUserStream(active: ActiveSubscription): Promise<void> {
   }
 
   const filteredNotifications = notifications.filter((notification) =>
-    NOTIFICATION_TYPES.includes(notification.type as (typeof NOTIFICATION_TYPES)[number]),
+    isSupportedNotificationType(notification.type),
   );
 
   for (const notification of [...filteredNotifications].reverse()) {

--- a/src/main/timeline.ts
+++ b/src/main/timeline.ts
@@ -1,10 +1,17 @@
 import { createRestAPIClient } from 'masto';
-import type { TimelineType, Post, PostVisibility } from '../shared/types.ts';
+import type {
+  AccountProfile,
+  AccountRelationshipSummary,
+  TimelineType,
+  Post,
+} from '../shared/types.ts';
+import { convertAccount, convertStatus } from './mastodonConverters.ts';
 
 export async function fetchTimeline(
   serverUrl: string,
   accessToken: string,
   type: TimelineType,
+  accountId?: string,
   maxId?: string,
 ): Promise<Post[]> {
   const client = createRestAPIClient({ url: serverUrl, accessToken });
@@ -25,62 +32,76 @@ export async function fetchTimeline(
     case 'favourites':
       statuses = await client.v1.favourites.list(params);
       break;
+    case 'account':
+      if (!accountId) {
+        throw new Error('アカウントTLの取得にはアカウントIDが必要です');
+      }
+      statuses = await client.v1.accounts.$select(accountId).statuses.list(params);
+      break;
     case 'notifications':
       return [];
   }
 
-  return statuses.map((status) => {
-    // If this is a reblog, use the original post's content
-    const original = status.reblog ?? status;
-    const rebloggedBy = status.reblog
-      ? {
-          acct: status.account.acct,
-          displayName: status.account.displayName,
-          avatarUrl: status.account.avatar,
-          emojis: status.account.emojis.map((e) => ({
-            shortcode: e.shortcode,
-            url: e.url,
-            staticUrl: e.staticUrl,
-          })),
-        }
-      : undefined;
+  return statuses.map(convertStatus);
+}
 
-    return {
-      id: status.id,
-      content: original.content,
-      createdAt: original.createdAt,
-      spoilerText: original.spoilerText,
-      sensitive: original.sensitive,
-      url: original.url ?? null,
-      visibility: original.visibility as PostVisibility,
-      account: {
-        acct: original.account.acct,
-        displayName: original.account.displayName,
-        avatarUrl: original.account.avatar,
-        emojis: original.account.emojis.map((e) => ({
-          shortcode: e.shortcode,
-          url: e.url,
-          staticUrl: e.staticUrl,
-        })),
-      },
-      mediaAttachments: original.mediaAttachments
-        .filter((m) => m.url != null && m.previewUrl != null)
-        .map((m) => ({
-          id: m.id,
-          type: m.type,
-          url: m.url!,
-          previewUrl: m.previewUrl!,
-          description: m.description ?? null,
-        })),
-      emojis: original.emojis.map((emoji) => ({
-        shortcode: emoji.shortcode,
-        url: emoji.url,
-        staticUrl: emoji.staticUrl,
-      })),
-      favourited: status.favourited ?? false,
-      reblogged: status.reblogged ?? false,
-      bookmarked: status.bookmarked ?? false,
-      rebloggedBy,
-    };
-  });
+export async function fetchAccountProfile(
+  serverUrl: string,
+  accessToken: string,
+  accountId: string,
+): Promise<AccountProfile> {
+  const client = createRestAPIClient({ url: serverUrl, accessToken });
+  const account = await client.v1.accounts.$select(accountId).fetch();
+  const profile = convertAccount(account);
+  const relationships = await client.v1.accounts.relationships.fetch({ id: [accountId] });
+  const relationshipSummary = relationships[0];
+  if (relationshipSummary) {
+    profile.following = relationshipSummary.following;
+    profile.requested = relationshipSummary.requested;
+  }
+
+  return profile;
+}
+
+export async function fetchAccountRelationship(
+  serverUrl: string,
+  accessToken: string,
+  accountId: string,
+): Promise<AccountRelationshipSummary> {
+  const client = createRestAPIClient({ url: serverUrl, accessToken });
+  const relationships = await client.v1.accounts.relationships.fetch({ id: [accountId] });
+  const relationship = relationships[0];
+  if (!relationship) {
+    return { following: false, requested: false };
+  }
+  return {
+    following: relationship.following,
+    requested: relationship.requested,
+  };
+}
+
+export async function followAccount(
+  serverUrl: string,
+  accessToken: string,
+  accountId: string,
+): Promise<AccountRelationshipSummary> {
+  const client = createRestAPIClient({ url: serverUrl, accessToken });
+  const relationship = await client.v1.accounts.$select(accountId).follow({});
+  return {
+    following: relationship.following,
+    requested: relationship.requested,
+  };
+}
+
+export async function unfollowAccount(
+  serverUrl: string,
+  accessToken: string,
+  accountId: string,
+): Promise<AccountRelationshipSummary> {
+  const client = createRestAPIClient({ url: serverUrl, accessToken });
+  const relationship = await client.v1.accounts.$select(accountId).unfollow({});
+  return {
+    following: relationship.following,
+    requested: relationship.requested,
+  };
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,10 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { IpcChannels } from '../shared/ipc.ts';
 import type {
   Account,
+  AccountProfile,
+  AccountProfileFetchParams,
+  AccountRelationshipParams,
+  AccountRelationshipSummary,
   AppSettings,
   MastoNotification,
   MediaUploadParams,
@@ -41,6 +45,22 @@ const api = {
   /** Fetch timeline posts */
   fetchTimeline(params: TimelineFetchParams): Promise<Post[]> {
     return ipcRenderer.invoke(IpcChannels.TimelineFetch, params);
+  },
+  /** Fetch an account profile */
+  fetchAccountProfile(params: AccountProfileFetchParams): Promise<AccountProfile> {
+    return ipcRenderer.invoke(IpcChannels.AccountProfileFetch, params);
+  },
+  /** Fetch an account relationship */
+  fetchAccountRelationship(params: AccountRelationshipParams): Promise<AccountRelationshipSummary> {
+    return ipcRenderer.invoke(IpcChannels.AccountRelationshipFetch, params);
+  },
+  /** Follow an account */
+  followAccount(params: AccountRelationshipParams): Promise<AccountRelationshipSummary> {
+    return ipcRenderer.invoke(IpcChannels.AccountFollow, params);
+  },
+  /** Unfollow an account */
+  unfollowAccount(params: AccountRelationshipParams): Promise<AccountRelationshipSummary> {
+    return ipcRenderer.invoke(IpcChannels.AccountUnfollow, params);
   },
   /** Fetch notifications */
   fetchNotifications(params: NotificationFetchParams): Promise<MastoNotification[]> {

--- a/src/renderer/components/CompactPostItem.tsx
+++ b/src/renderer/components/CompactPostItem.tsx
@@ -8,6 +8,7 @@ import { replaceCustomEmojis } from './customEmojis.ts';
 interface CompactPostItemProps {
   post: Post;
   onClick: () => void;
+  onOpenAccountTimeline?: (account: Post['account']) => void;
 }
 
 const Row = styled.div<{ $rowHeight: number }>`
@@ -32,19 +33,27 @@ const IconCell = styled.div`
   overflow: hidden;
 `;
 
-const CompactAvatar = styled.img<{ $rowHeight: number }>`
+const CompactAvatar = styled.img<{ $rowHeight: number; $clickable: boolean }>`
   width: 35px;
   height: ${(props) => Math.max(props.$rowHeight, 14)}px;
   object-fit: cover;
+  cursor: ${(props) => (props.$clickable ? 'pointer' : 'inherit')};
 `;
 
-const AcctCell = styled.div<{ $boosted: boolean }>`
+const AcctCellButton = styled.button<{ $boosted: boolean }>`
   background: ${(props) => (props.$boosted ? '#fff1f0' : '#fffbe6')};
   height: 100%;
   display: flex;
   align-items: center;
-  padding: 0 0;
+  padding: 0;
+  border: 0;
+  width: 100%;
   overflow: hidden;
+  appearance: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
 `;
 
 const AcctText = styled.span<{ $fontSize: number }>`
@@ -143,7 +152,11 @@ function escapeHtml(text: string): string {
   return div.innerHTML;
 }
 
-export function CompactPostItem({ post, onClick }: CompactPostItemProps): React.JSX.Element {
+export function CompactPostItem({
+  post,
+  onClick,
+  onOpenAccountTimeline,
+}: CompactPostItemProps): React.JSX.Element {
   const { settings } = useSettings();
   const compactFontSize = Math.max(settings.compactFontSize, 8);
   const rowHeight = Math.max(compactFontSize + 10, 20);
@@ -158,13 +171,24 @@ export function CompactPostItem({ post, onClick }: CompactPostItemProps): React.
       <IconCell>
         <CompactAvatar
           $rowHeight={rowHeight}
+          $clickable={false}
           src={post.account.avatarUrl}
           alt={post.account.acct}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
         />
       </IconCell>
-      <AcctCell $boosted={!!post.rebloggedBy}>
+      <AcctCellButton
+        type="button"
+        $boosted={!!post.rebloggedBy}
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpenAccountTimeline?.(post.account);
+        }}
+      >
         <AcctText $fontSize={compactFontSize}>{shortAcct(post.account.acct)}</AcctText>
-      </AcctCell>
+      </AcctCellButton>
       <BodyCell $visibility={post.visibility} $hasSpoiler={hasSpoiler}>
         <BodyText $fontSize={compactFontSize} dangerouslySetInnerHTML={{ __html: bodyHtml }} />
         {hasMedia && <MediaIcon $fontSize={compactFontSize} />}

--- a/src/renderer/components/NotificationItem.tsx
+++ b/src/renderer/components/NotificationItem.tsx
@@ -12,6 +12,7 @@ import { replaceCustomEmojis } from './customEmojis.ts';
 
 interface NotificationItemProps {
   notification: MastoNotification;
+  onOpenAccountTimeline?: (account: MastoNotification['account']) => void;
 }
 
 const NotificationContainer = styled.div`
@@ -47,6 +48,21 @@ const Acct = styled.span`
 
 const NotificationMessage = styled.span`
   color: #8c8c8c;
+`;
+
+const IdentityButton = styled.button`
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover .notification-acct {
+    color: #1677ff;
+  }
 `;
 
 const StatusPreview = styled.div<{ $fontSize: number }>`
@@ -115,7 +131,10 @@ function sanitizeContent(html: string): string {
   });
 }
 
-export function NotificationItem({ notification }: NotificationItemProps): React.JSX.Element {
+export function NotificationItem({
+  notification,
+  onOpenAccountTimeline,
+}: NotificationItemProps): React.JSX.Element {
   const { settings } = useSettings();
 
   return (
@@ -124,14 +143,18 @@ export function NotificationItem({ notification }: NotificationItemProps): React
         $size={settings.avatarSize}
         src={notification.account.avatarUrl}
         alt={notification.account.acct}
+        style={undefined}
       />
       <Content>
         <NotificationHeader $fontSize={settings.uiFontSize}>
           {NOTIFICATION_ICON[notification.type]}
-          <span>
-            <Acct>@{notification.account.acct}</Acct>
+          <IdentityButton
+            type="button"
+            onClick={() => onOpenAccountTimeline?.(notification.account)}
+          >
+            <Acct className="notification-acct">@{notification.account.acct}</Acct>
             <NotificationMessage>{NOTIFICATION_LABEL[notification.type]}</NotificationMessage>
-          </span>
+          </IdentityButton>
         </NotificationHeader>
         {notification.status && (
           <StatusPreview

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -19,6 +19,7 @@ interface PostItemProps {
   serverUrl: string;
   accessToken: string;
   onReply?: (post: Post) => void;
+  onOpenAccountTimeline?: (account: Post['account']) => void;
   onCollapse?: () => void;
 }
 
@@ -82,6 +83,27 @@ const HeaderLine = styled.div<{ $mastodonLike: boolean }>`
   gap: ${(props) => (props.$mastodonLike ? '0' : '8px')};
   align-items: ${(props) => (props.$mastodonLike ? 'flex-start' : 'baseline')};
   margin-bottom: 4px;
+`;
+
+const ProfileIdentityButton = styled.button<{ $mastodonLike: boolean }>`
+  display: inline-flex;
+  flex-direction: ${(props) => (props.$mastodonLike ? 'column' : 'row')};
+  gap: ${(props) => (props.$mastodonLike ? '0' : '8px')};
+  align-items: ${(props) => (props.$mastodonLike ? 'flex-start' : 'baseline')};
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  min-width: 0;
+
+  &:hover .profile-name,
+  &:hover .profile-acct {
+    color: #1677ff;
+  }
 `;
 
 const Acct = styled.span<{ $fontSize: number }>`
@@ -231,6 +253,7 @@ export function PostItem({
   serverUrl,
   accessToken,
   onReply,
+  onOpenAccountTimeline,
   onCollapse,
 }: PostItemProps): React.JSX.Element {
   const { settings } = useSettings();
@@ -280,6 +303,10 @@ export function PostItem({
     }
   };
 
+  const handleAvatarClick = (): void => {
+    onCollapse?.();
+  };
+
   const smallFontSize = settings.uiFontSize - 2;
   const hasMediaAttachments = post.mediaAttachments.length > 0;
   const isSensitiveWithoutContentWarning = post.sensitive && !hasContentWarning;
@@ -293,7 +320,7 @@ export function PostItem({
           $size={settings.avatarSize}
           src={post.account.avatarUrl}
           alt={post.account.acct}
-          onClick={onCollapse}
+          onClick={handleAvatarClick}
           style={onCollapse ? { cursor: 'pointer' } : undefined}
         />
         {post.rebloggedBy && (
@@ -309,27 +336,37 @@ export function PostItem({
       </AvatarColumn>
       <Content>
         <HeaderLine $mastodonLike={settings.mastodonLikeExpandedDisplay}>
-          {settings.mastodonLikeExpandedDisplay && (
-            <DisplayName
-              $fontSize={settings.uiFontSize}
-              dangerouslySetInnerHTML={{
-                __html: sanitizeContent(
-                  replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
-                ),
-              }}
-            />
-          )}
-          <Acct $fontSize={settings.uiFontSize}>@{post.account.acct}</Acct>
-          {!settings.mastodonLikeExpandedDisplay && (
-            <DisplayName
-              $fontSize={settings.uiFontSize}
-              dangerouslySetInnerHTML={{
-                __html: sanitizeContent(
-                  replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
-                ),
-              }}
-            />
-          )}
+          <ProfileIdentityButton
+            type="button"
+            $mastodonLike={settings.mastodonLikeExpandedDisplay}
+            onClick={() => onOpenAccountTimeline?.(post.account)}
+          >
+            {settings.mastodonLikeExpandedDisplay && (
+              <DisplayName
+                className="profile-name"
+                $fontSize={settings.uiFontSize}
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeContent(
+                    replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
+                  ),
+                }}
+              />
+            )}
+            <Acct className="profile-acct" $fontSize={settings.uiFontSize}>
+              @{post.account.acct}
+            </Acct>
+            {!settings.mastodonLikeExpandedDisplay && (
+              <DisplayName
+                className="profile-name"
+                $fontSize={settings.uiFontSize}
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeContent(
+                    replaceCustomEmojis(escapeHtml(post.account.displayName), post.account.emojis),
+                  ),
+                }}
+              />
+            )}
+          </ProfileIdentityButton>
         </HeaderLine>
         {hasContentWarning && (
           <ContentWarning $fontSize={settings.postFontSize} onClick={() => setExpanded(!expanded)}>

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -12,10 +12,19 @@ import {
   Tooltip,
   Input,
 } from 'antd';
-import { SettingOutlined, UserOutlined, MoreOutlined } from '@ant-design/icons';
+import {
+  SettingOutlined,
+  UserOutlined,
+  MoreOutlined,
+  UserAddOutlined,
+  UserDeleteOutlined,
+} from '@ant-design/icons';
+import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import type {
   Account,
+  AccountProfile,
+  AccountProfileField,
   MastoNotification,
   PaneDefinition,
   Post,
@@ -30,6 +39,7 @@ import { Composer } from '../components/Composer.tsx';
 import { CompactPostItem } from '../components/CompactPostItem.tsx';
 import { PaneContainer } from '../components/PaneContainer.tsx';
 import { useSettings } from '../hooks/useSettings.ts';
+import { replaceCustomEmojis } from '../components/customEmojis.ts';
 
 const { Text } = Typography;
 
@@ -38,6 +48,11 @@ interface ComposerReplyDraft {
   username: string;
   inReplyToId: string;
   mentionAcct: string;
+}
+
+interface AccountTimelineTarget {
+  id: string;
+  acct: string;
 }
 
 interface TimelinePageProps {
@@ -55,6 +70,169 @@ const PageContainer = styled.div`
 const TimelineList = styled.div`
   flex: 1;
   overflow-y: auto;
+`;
+
+const AccountHeader = styled.div`
+  border-bottom: 1px solid #f0f0f0;
+  background: #fff;
+`;
+
+const AccountHeaderImage = styled.img`
+  display: block;
+  width: 100%;
+  height: 140px;
+  background-color: #f5f5f5;
+  object-fit: cover;
+`;
+
+const AccountHeaderBody = styled.div`
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 16px;
+  padding: 0 16px 16px;
+`;
+
+const AccountHeaderAvatar = styled.img`
+  width: 96px;
+  height: 96px;
+  border-radius: 8px;
+  border: 4px solid #fff;
+  margin-top: -32px;
+  background: #fff;
+`;
+
+const AccountHeaderContent = styled.div`
+  min-width: 0;
+  padding-top: 12px;
+`;
+
+const AccountHeaderTop = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+`;
+
+const AccountIdentityButton = styled.button`
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  min-width: 0;
+`;
+
+const AccountDisplayName = styled.div`
+  font-weight: 700;
+  font-size: 18px;
+  color: #262626;
+  word-break: break-word;
+
+  .custom-emoji {
+    height: 1em;
+    width: auto;
+    vertical-align: middle;
+    margin: 0 1px;
+  }
+`;
+
+const AccountAcct = styled.div`
+  display: inline-block;
+  color: #8c8c8c;
+  margin-top: 2px;
+`;
+
+const AccountNote = styled.div`
+  margin-top: 8px;
+  color: #262626;
+  line-height: 1.5;
+  word-break: break-word;
+
+  p {
+    margin: 0 0 4px;
+  }
+
+  a {
+    color: #1677ff;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .custom-emoji {
+    height: 1em;
+    width: auto;
+    vertical-align: middle;
+  }
+`;
+
+const AccountFields = styled.div`
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+`;
+
+const AccountFieldItem = styled.div`
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  align-items: start;
+`;
+
+const AccountFieldName = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  color: #595959;
+  word-break: break-word;
+`;
+
+const AccountFieldValue = styled.div`
+  color: #262626;
+  line-height: 1.5;
+  word-break: break-word;
+
+  p {
+    margin: 0 0 4px;
+  }
+
+  a {
+    color: #1677ff;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .custom-emoji {
+    height: 1em;
+    width: auto;
+    vertical-align: middle;
+  }
+`;
+
+const AccountFieldVerified = styled.span`
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: #389e0d;
+`;
+
+const AccountHeaderActions = styled.div`
+  display: flex;
+  flex-shrink: 0;
+`;
+
+const AccountStats = styled.div`
+  display: flex;
+  gap: 16px;
+  margin-top: 10px;
+  color: #8c8c8c;
 `;
 
 const EmptyMessage = styled.div`
@@ -123,7 +301,16 @@ const TIMELINE_TYPE_LABELS: Record<TimelineType, string> = {
   local: 'Local',
   favourites: 'Favourites',
   notifications: 'Notifications',
+  account: 'Account',
 };
+
+const TIMELINE_TYPE_OPTIONS: { value: TimelineType; label: string }[] = [
+  { value: 'home', label: 'Home' },
+  { value: 'public', label: 'Public' },
+  { value: 'local', label: 'Local' },
+  { value: 'favourites', label: 'Favourites' },
+  { value: 'notifications', label: 'Notifications' },
+];
 
 function generateId(): string {
   return crypto.randomUUID();
@@ -146,6 +333,9 @@ function buildTabLabel(tab: TabDefinition, accounts: Account[]): string {
   if (tab.customName && tab.customName.trim().length > 0) {
     return tab.customName;
   }
+  if (tab.timelineType === 'account' && tab.targetAccountAcct) {
+    return `@${tab.targetAccountAcct}`;
+  }
   const account = accounts.find(
     (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
   );
@@ -153,26 +343,168 @@ function buildTabLabel(tab: TabDefinition, accounts: Account[]): string {
   return `${TIMELINE_TYPE_LABELS[tab.timelineType]} ${acct}`;
 }
 
+function sanitizeProfileHtml(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: ['a', 'br', 'p', 'span', 'em', 'strong', 'b', 'i', 'u', 'code', 'img'],
+    allowedAttributes: {
+      a: ['href', 'rel', 'target', 'class'],
+      span: ['class'],
+      img: ['src', 'alt', 'title', 'class'],
+    },
+  });
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const countFormatter = new Intl.NumberFormat();
+
+function formatCount(count: number): string {
+  return countFormatter.format(count);
+}
+
+function handleAccountProfileLinkClick(event: React.MouseEvent): void {
+  const anchor = event.target instanceof Element ? event.target.closest('a') : null;
+  if (!anchor) return;
+
+  event.preventDefault();
+  const url = anchor.getAttribute('href');
+  if (url && (url.startsWith('https://') || url.startsWith('http://'))) {
+    window.open(url, '_blank');
+  }
+}
+
+function renderAccountField(
+  field: AccountProfileField,
+  emojis: AccountProfile['emojis'],
+): React.JSX.Element {
+  return (
+    <AccountFieldItem key={`${field.name}-${field.value}`}>
+      <AccountFieldName>{field.name}</AccountFieldName>
+      <div>
+        <AccountFieldValue
+          onClick={handleAccountProfileLinkClick}
+          dangerouslySetInnerHTML={{
+            __html: sanitizeProfileHtml(replaceCustomEmojis(field.value, emojis)),
+          }}
+        />
+        {field.verifiedAt && <AccountFieldVerified>認証済み</AccountFieldVerified>}
+      </div>
+    </AccountFieldItem>
+  );
+}
+
+function AccountProfileHeader({
+  profile,
+  onToggleFollow,
+  followBusy,
+}: {
+  profile: AccountProfile;
+  onToggleFollow: () => void;
+  followBusy: boolean;
+}): React.JSX.Element {
+  const displayName = profile.displayName.trim().length > 0 ? profile.displayName : profile.acct;
+  const followLabel = profile.requested
+    ? 'リクエスト中'
+    : profile.following
+      ? 'フォロー中'
+      : 'フォロー';
+  const followIcon =
+    profile.requested || profile.following ? <UserDeleteOutlined /> : <UserAddOutlined />;
+
+  return (
+    <AccountHeader>
+      <AccountHeaderImage src={profile.headerUrl} alt="" />
+      <AccountHeaderBody>
+        <AccountHeaderAvatar src={profile.avatarUrl} alt={profile.acct} />
+        <AccountHeaderContent>
+          <AccountHeaderTop>
+            <div>
+              <AccountDisplayName
+                dangerouslySetInnerHTML={{
+                  __html: sanitizeProfileHtml(
+                    replaceCustomEmojis(escapeHtml(displayName), profile.emojis),
+                  ),
+                }}
+              />
+              <AccountIdentityButton
+                type="button"
+                onClick={(event) => {
+                  event.preventDefault();
+                  window.open(profile.url, '_blank');
+                }}
+              >
+                <AccountAcct>@{profile.acct}</AccountAcct>
+              </AccountIdentityButton>
+            </div>
+            <AccountHeaderActions>
+              <Button
+                type={profile.following || profile.requested ? 'default' : 'primary'}
+                icon={followIcon}
+                loading={followBusy}
+                onClick={onToggleFollow}
+                disabled={followBusy}
+              >
+                {followLabel}
+              </Button>
+            </AccountHeaderActions>
+          </AccountHeaderTop>
+          {profile.note.trim().length > 0 && (
+            <AccountNote
+              onClick={handleAccountProfileLinkClick}
+              dangerouslySetInnerHTML={{
+                __html: sanitizeProfileHtml(replaceCustomEmojis(profile.note, profile.emojis)),
+              }}
+            />
+          )}
+          {profile.fields.length > 0 && (
+            <AccountFields>
+              {profile.fields.map((field) => renderAccountField(field, profile.emojis))}
+            </AccountFields>
+          )}
+          <AccountStats>
+            <span>{formatCount(profile.statusesCount)} 投稿</span>
+            <span>{formatCount(profile.followingCount)} フォロー</span>
+            <span>{formatCount(profile.followersCount)} フォロワー</span>
+          </AccountStats>
+        </AccountHeaderContent>
+      </AccountHeaderBody>
+    </AccountHeader>
+  );
+}
+
 function TimelineTabContent({
   tab,
   accounts,
   onReply,
+  onOpenAccountTimeline,
 }: {
   tab: TabDefinition;
   accounts: Account[];
   onReply: (tab: TabDefinition, post: Post) => void;
+  onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }): React.JSX.Element {
   const { message } = App.useApp();
   const [posts, setPosts] = useState<Post[]>([]);
+  const [accountProfile, setAccountProfile] = useState<AccountProfile | null>(null);
+  const [followBusy, setFollowBusy] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [expandedPostId, setExpandedPostId] = useState<string | null>(null);
   const { settings } = useSettings();
   const listRef = useRef<HTMLDivElement>(null);
   const postsRef = useRef(posts);
-  postsRef.current = posts;
   const loadingMoreRef = useRef(false);
   const hasMoreRef = useRef(true);
+
+  useEffect(() => {
+    postsRef.current = posts;
+  }, [posts]);
 
   const account = accounts.find(
     (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
@@ -183,10 +515,24 @@ function TimelineTabContent({
     setLoading(true);
     hasMoreRef.current = true;
     try {
+      if (tab.timelineType === 'account') {
+        if (!tab.targetAccountId) {
+          throw new Error('アカウントIDが設定されていません');
+        }
+        const profile = await window.api.fetchAccountProfile({
+          serverUrl: account.serverUrl,
+          accessToken: account.accessToken,
+          accountId: tab.targetAccountId,
+        });
+        setAccountProfile(profile);
+      } else {
+        setAccountProfile(null);
+      }
       const result = await window.api.fetchTimeline({
         serverUrl: account.serverUrl,
         accessToken: account.accessToken,
         type: tab.timelineType,
+        accountId: tab.targetAccountId,
       });
       setPosts(result);
     } catch (e) {
@@ -196,12 +542,47 @@ function TimelineTabContent({
     } finally {
       setLoading(false);
     }
-  }, [account, tab.timelineType, message]);
+  }, [account, tab.timelineType, tab.targetAccountId, message]);
 
   const handleRefresh = useCallback(() => {
     setPosts([]);
     void loadTimeline();
   }, [loadTimeline]);
+
+  const handleToggleFollow = useCallback(async (): Promise<void> => {
+    if (!account || !accountProfile) return;
+    if (!tab.targetAccountId) return;
+
+    setFollowBusy(true);
+    try {
+      const result =
+        accountProfile.following || accountProfile.requested
+          ? await window.api.unfollowAccount({
+              serverUrl: account.serverUrl,
+              accessToken: account.accessToken,
+              accountId: tab.targetAccountId,
+            })
+          : await window.api.followAccount({
+              serverUrl: account.serverUrl,
+              accessToken: account.accessToken,
+              accountId: tab.targetAccountId,
+            });
+
+      setAccountProfile((prev) =>
+        prev
+          ? {
+              ...prev,
+              following: result.following,
+              requested: result.requested,
+            }
+          : prev,
+      );
+    } catch (e) {
+      message.error(`フォロー操作に失敗しました: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setFollowBusy(false);
+    }
+  }, [account, accountProfile, message, tab.targetAccountId]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
@@ -227,6 +608,7 @@ function TimelineTabContent({
         serverUrl: account.serverUrl,
         accessToken: account.accessToken,
         type: tab.timelineType,
+        accountId: tab.targetAccountId,
         maxId: lastPost.id,
       });
       if (result.length > 0) {
@@ -242,7 +624,7 @@ function TimelineTabContent({
       loadingMoreRef.current = false;
       setLoadingMore(false);
     }
-  }, [account, tab.timelineType, message]);
+  }, [account, tab.timelineType, tab.targetAccountId, message]);
 
   useEffect(() => {
     loadTimeline();
@@ -257,7 +639,7 @@ function TimelineTabContent({
       }
     };
     checkAndLoad();
-    el.addEventListener('scroll', checkAndLoad);
+    el.addEventListener('scroll', checkAndLoad, { passive: true });
     return () => el.removeEventListener('scroll', checkAndLoad);
   }, [loadMore, posts.length]);
 
@@ -303,12 +685,20 @@ function TimelineTabContent({
     );
   }
 
-  if (posts.length === 0) {
+  if (posts.length === 0 && tab.timelineType !== 'account') {
     return <EmptyMessage>投稿がありません</EmptyMessage>;
   }
 
   return (
     <TimelineList ref={listRef}>
+      {accountProfile && (
+        <AccountProfileHeader
+          profile={accountProfile}
+          onToggleFollow={handleToggleFollow}
+          followBusy={followBusy}
+        />
+      )}
+      {posts.length === 0 && <EmptyMessage>投稿がありません</EmptyMessage>}
       {posts.map((post) =>
         settings.disableCompactDisplay || expandedPostId === post.id ? (
           <PostItem
@@ -317,10 +707,16 @@ function TimelineTabContent({
             serverUrl={account.serverUrl}
             accessToken={account.accessToken}
             onReply={(targetPost) => onReply(tab, targetPost)}
+            onOpenAccountTimeline={(targetAccount) => onOpenAccountTimeline(tab, targetAccount)}
             onCollapse={settings.disableCompactDisplay ? undefined : () => setExpandedPostId(null)}
           />
         ) : (
-          <CompactPostItem key={post.id} post={post} onClick={() => setExpandedPostId(post.id)} />
+          <CompactPostItem
+            key={post.id}
+            post={post}
+            onClick={() => setExpandedPostId(post.id)}
+            onOpenAccountTimeline={(targetAccount) => onOpenAccountTimeline(tab, targetAccount)}
+          />
         ),
       )}
       {loadingMore && (
@@ -335,9 +731,11 @@ function TimelineTabContent({
 function NotificationTabContent({
   tab,
   accounts,
+  onOpenAccountTimeline,
 }: {
   tab: TabDefinition;
   accounts: Account[];
+  onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }): React.JSX.Element {
   const { message } = App.useApp();
   const [notifications, setNotifications] = useState<MastoNotification[]>([]);
@@ -345,10 +743,13 @@ function NotificationTabContent({
   const [loadingMore, setLoadingMore] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const notificationsRef = useRef(notifications);
-  notificationsRef.current = notifications;
   const notificationsEnabledRef = useRef(true);
   const loadingMoreRef = useRef(false);
   const hasMoreRef = useRef(true);
+
+  useEffect(() => {
+    notificationsRef.current = notifications;
+  }, [notifications]);
 
   const account = accounts.find(
     (a) => a.serverUrl === tab.accountServerUrl && a.username === tab.accountUsername,
@@ -413,7 +814,7 @@ function NotificationTabContent({
       }
     };
     checkAndLoad();
-    el.addEventListener('scroll', checkAndLoad);
+    el.addEventListener('scroll', checkAndLoad, { passive: true });
     return () => el.removeEventListener('scroll', checkAndLoad);
   }, [loadMoreNotifications, notifications.length]);
 
@@ -494,7 +895,11 @@ function NotificationTabContent({
   return (
     <TimelineList ref={listRef}>
       {notifications.map((notification) => (
-        <NotificationItem key={notification.id} notification={notification} />
+        <NotificationItem
+          key={notification.id}
+          notification={notification}
+          onOpenAccountTimeline={(target) => onOpenAccountTimeline(tab, target)}
+        />
       ))}
       {loadingMore && (
         <SpinContainer>
@@ -509,15 +914,30 @@ function TabContent({
   tab,
   accounts,
   onReply,
+  onOpenAccountTimeline,
 }: {
   tab: TabDefinition;
   accounts: Account[];
   onReply: (tab: TabDefinition, post: Post) => void;
+  onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }): React.JSX.Element {
   if (tab.timelineType === 'notifications') {
-    return <NotificationTabContent tab={tab} accounts={accounts} />;
+    return (
+      <NotificationTabContent
+        tab={tab}
+        accounts={accounts}
+        onOpenAccountTimeline={onOpenAccountTimeline}
+      />
+    );
   }
-  return <TimelineTabContent tab={tab} accounts={accounts} onReply={onReply} />;
+  return (
+    <TimelineTabContent
+      tab={tab}
+      accounts={accounts}
+      onReply={onReply}
+      onOpenAccountTimeline={onOpenAccountTimeline}
+    />
+  );
 }
 
 interface PaneProps {
@@ -532,6 +952,7 @@ interface PaneProps {
   onMoveTab: (tabId: string, fromPaneId: string, direction: 'left' | 'right') => void;
   onRenameTab: (tabId: string, name: string) => void;
   onReply: (tab: TabDefinition, post: Post) => void;
+  onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }
 
 function getSubscriptionIds(tab: TabDefinition): string[] {
@@ -555,6 +976,7 @@ function Pane({
   onMoveTab,
   onRenameTab,
   onReply,
+  onOpenAccountTimeline,
 }: PaneProps): React.JSX.Element {
   const [connectionStatuses, setConnectionStatuses] = useState<
     Record<string, StreamConnectionStatus>
@@ -627,7 +1049,14 @@ function Pane({
           })()}
         </TabLabelWrapper>
       ),
-      children: <TabContent tab={tab} accounts={accounts} onReply={onReply} />,
+      children: (
+        <TabContent
+          tab={tab}
+          accounts={accounts}
+          onReply={onReply}
+          onOpenAccountTimeline={onOpenAccountTimeline}
+        />
+      ),
       closable: paneTabs.length > 1 || totalPanes > 1,
     };
   });
@@ -940,14 +1369,6 @@ export function TimelinePage({
     label: `@${a.username}@${new URL(a.serverUrl).host}`,
   }));
 
-  const timelineTypeOptions: { value: TimelineType; label: string }[] = [
-    { value: 'home', label: 'Home' },
-    { value: 'public', label: 'Public' },
-    { value: 'local', label: 'Local' },
-    { value: 'favourites', label: 'Favourites' },
-    { value: 'notifications', label: 'Notifications' },
-  ];
-
   const handleReply = useCallback((tab: TabDefinition, post: Post): void => {
     setReplyDraft({
       serverUrl: tab.accountServerUrl,
@@ -956,6 +1377,41 @@ export function TimelinePage({
       mentionAcct: post.account.acct,
     });
   }, []);
+
+  const handleOpenAccountTimeline = useCallback(
+    (sourceTab: TabDefinition, target: AccountTimelineTarget): void => {
+      const targetPane = panes.find((pane) => pane.tabIds.includes(sourceTab.id)) ?? panes[0];
+      if (!targetPane) return;
+
+      const accountTab: TabDefinition = {
+        id: generateId(),
+        accountServerUrl: sourceTab.accountServerUrl,
+        accountUsername: sourceTab.accountUsername,
+        timelineType: 'account',
+        targetAccountId: target.id,
+        targetAccountAcct: target.acct,
+      };
+
+      setTabs((prevTabs) => {
+        const nextTabs = [...prevTabs, accountTab];
+        setPanes((prevPanes) => {
+          const nextPanes = prevPanes.map((pane) =>
+            pane.id === targetPane.id
+              ? {
+                  ...pane,
+                  tabIds: [...pane.tabIds, accountTab.id],
+                  activeTabId: accountTab.id,
+                }
+              : pane,
+          );
+          persistLayout(nextTabs, nextPanes);
+          return nextPanes;
+        });
+        return nextTabs;
+      });
+    },
+    [panes, persistLayout],
+  );
 
   const handleClearReplyDraft = useCallback((): void => {
     setReplyDraft(null);
@@ -1010,6 +1466,7 @@ export function TimelinePage({
             onMoveTab={handleMoveTab}
             onRenameTab={handleRenameTab}
             onReply={handleReply}
+            onOpenAccountTimeline={handleOpenAccountTimeline}
           />
         ))}
       </PaneContainer>
@@ -1040,7 +1497,7 @@ export function TimelinePage({
               style={{ width: '100%', marginTop: 8 }}
               value={newTabType}
               onChange={setNewTabType}
-              options={timelineTypeOptions}
+              options={TIMELINE_TYPE_OPTIONS}
             />
           </div>
           <div>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,6 +10,14 @@ export const IpcChannels = {
   AccountsRemove: 'accounts:remove',
   /** Fetch timeline posts */
   TimelineFetch: 'timeline:fetch',
+  /** Fetch a Mastodon account profile */
+  AccountProfileFetch: 'account-profile:fetch',
+  /** Fetch an account relationship */
+  AccountRelationshipFetch: 'account-relationship:fetch',
+  /** Follow an account */
+  AccountFollow: 'account:follow',
+  /** Unfollow an account */
+  AccountUnfollow: 'account:unfollow',
   /** Fetch notifications */
   NotificationsFetch: 'notifications:fetch',
   /** Post a new status */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -18,6 +18,8 @@ export interface TabDefinition {
   accountServerUrl: string;
   accountUsername: string;
   timelineType: TimelineType;
+  targetAccountId?: string;
+  targetAccountAcct?: string;
   customName?: string;
 }
 
@@ -191,7 +193,7 @@ export interface OAuthExchangeTokenParams {
 }
 
 /** Timeline type */
-export type TimelineType = 'home' | 'public' | 'local' | 'favourites' | 'notifications';
+export type TimelineType = 'home' | 'public' | 'local' | 'favourites' | 'notifications' | 'account';
 
 /** Media attachment type */
 export type MediaAttachmentType = 'image' | 'video' | 'gifv' | 'audio' | 'unknown';
@@ -221,6 +223,7 @@ export interface Post {
   createdAt: string;
   url: string | null;
   account: {
+    id: string;
     acct: string;
     displayName: string;
     avatarUrl: string;
@@ -233,6 +236,7 @@ export interface Post {
   bookmarked: boolean;
   emojis: PostCustomEmoji[];
   rebloggedBy?: {
+    id: string;
     acct: string;
     displayName: string;
     avatarUrl: string;
@@ -244,7 +248,49 @@ export interface TimelineFetchParams {
   serverUrl: string;
   accessToken: string;
   type: TimelineType;
+  accountId?: string;
   maxId?: string;
+}
+
+export interface AccountProfile {
+  id: string;
+  acct: string;
+  username: string;
+  displayName: string;
+  note: string;
+  avatarUrl: string;
+  headerUrl: string;
+  url: string;
+  followersCount: number;
+  followingCount: number;
+  statusesCount: number;
+  following: boolean;
+  requested: boolean;
+  emojis: PostCustomEmoji[];
+  fields: AccountProfileField[];
+}
+
+export interface AccountProfileField {
+  name: string;
+  value: string;
+  verifiedAt?: string | null;
+}
+
+export interface AccountRelationshipSummary {
+  following: boolean;
+  requested: boolean;
+}
+
+export interface AccountProfileFetchParams {
+  serverUrl: string;
+  accessToken: string;
+  accountId: string;
+}
+
+export interface AccountRelationshipParams {
+  serverUrl: string;
+  accessToken: string;
+  accountId: string;
 }
 
 export interface PaneDefinition {
@@ -280,6 +326,7 @@ export interface MastoNotification {
   type: NotificationType;
   createdAt: string;
   account: {
+    id: string;
     acct: string;
     displayName: string;
     avatarUrl: string;


### PR DESCRIPTION
closes #40 

## Summary
- Open account timelines from username clicks instead of avatar clicks
- Render profile fields on account timeline headers
- Add follow/unfollow actions in the profile header
- Harden profile link navigation and support follow state fetch/update

## Verification
- bun run format
- bun run typecheck
- bun run lint
- bun run build
- bun test (no tests found)
