### PR TITLE
feat: support quoted posts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -194,6 +194,7 @@ function registerIpcHandlers(): void {
         params.spoilerText,
         params.visibility,
         params.inReplyToId,
+        params.quotedStatusId,
         params.mediaIds,
       ),
     );

--- a/src/main/mastodonConverters.ts
+++ b/src/main/mastodonConverters.ts
@@ -4,7 +4,9 @@ import type {
   AccountProfileField,
   MastoNotification,
   Post,
+  PostQuote,
   PostVisibility,
+  QuotedPost,
 } from '../shared/types.ts';
 
 const NOTIFICATION_TYPES = ['follow', 'follow_request', 'favourite', 'reblog'] as const;
@@ -29,6 +31,56 @@ function convertFields(fields: mastodon.v1.AccountField[]): AccountProfileField[
     value: field.value,
     verifiedAt: field.verifiedAt ?? null,
   }));
+}
+
+function convertMediaAttachments(
+  mediaAttachments: mastodon.v1.MediaAttachment[],
+): Post['mediaAttachments'] {
+  return mediaAttachments
+    .filter((media) => media.url != null && media.previewUrl != null)
+    .map((media) => ({
+      id: media.id,
+      type: media.type,
+      url: media.url!,
+      previewUrl: media.previewUrl!,
+      description: media.description ?? null,
+    }));
+}
+
+function convertQuotedStatus(status: mastodon.v1.Status): QuotedPost {
+  return {
+    id: status.id,
+    content: status.content,
+    createdAt: status.createdAt,
+    spoilerText: status.spoilerText,
+    sensitive: status.sensitive,
+    url: status.url ?? null,
+    visibility: status.visibility as PostVisibility,
+    account: {
+      id: status.account.id,
+      acct: status.account.acct,
+      displayName: status.account.displayName,
+      avatarUrl: status.account.avatar,
+      emojis: convertEmojis(status.account.emojis),
+    },
+    mediaAttachments: convertMediaAttachments(status.mediaAttachments),
+    emojis: convertEmojis(status.emojis),
+  };
+}
+
+function convertQuote(quote: mastodon.v1.Status['quote']): PostQuote | undefined {
+  if (!quote) {
+    return undefined;
+  }
+
+  return {
+    state: quote.state,
+    quotedStatusId: 'quotedStatusId' in quote ? (quote.quotedStatusId ?? undefined) : undefined,
+    quotedPost:
+      'quotedStatus' in quote && quote.quotedStatus
+        ? convertQuotedStatus(quote.quotedStatus)
+        : undefined,
+  };
 }
 
 export function convertAccount(account: mastodon.v1.Account): AccountProfile {
@@ -77,20 +129,13 @@ export function convertStatus(status: mastodon.v1.Status): Post {
       avatarUrl: original.account.avatar,
       emojis: convertEmojis(original.account.emojis),
     },
-    mediaAttachments: original.mediaAttachments
-      .filter((media) => media.url != null && media.previewUrl != null)
-      .map((media) => ({
-        id: media.id,
-        type: media.type,
-        url: media.url!,
-        previewUrl: media.previewUrl!,
-        description: media.description ?? null,
-      })),
+    mediaAttachments: convertMediaAttachments(original.mediaAttachments),
     emojis: convertEmojis(original.emojis),
     favourited: status.favourited ?? false,
     reblogged: status.reblogged ?? false,
     bookmarked: status.bookmarked ?? false,
     rebloggedBy,
+    quote: convertQuote(original.quote),
   };
 }
 

--- a/src/main/statuses.ts
+++ b/src/main/statuses.ts
@@ -8,6 +8,7 @@ export async function createStatus(
   spoilerText: string | undefined,
   visibility: PostVisibility,
   inReplyToId?: string,
+  quotedStatusId?: string,
   mediaIds?: string[],
 ): Promise<void> {
   const client = createRestAPIClient({ url: serverUrl, accessToken });
@@ -19,6 +20,7 @@ export async function createStatus(
       spoilerText: normalizedSpoilerText,
       visibility,
       inReplyToId,
+      quotedStatusId,
       mediaIds,
     });
     return;
@@ -29,6 +31,7 @@ export async function createStatus(
     spoilerText: normalizedSpoilerText,
     visibility,
     inReplyToId,
+    quotedStatusId,
   });
 }
 

--- a/src/renderer/components/CompactPostItem.tsx
+++ b/src/renderer/components/CompactPostItem.tsx
@@ -1,4 +1,4 @@
-import { PictureOutlined } from '@ant-design/icons';
+import { LinkOutlined, PictureOutlined } from '@ant-design/icons';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import type { Post } from '../../shared/types.ts';
@@ -100,6 +100,13 @@ const MediaIcon = styled(PictureOutlined)<{ $fontSize: number }>`
   margin-left: 4px;
 `;
 
+const QuoteIcon = styled(LinkOutlined)<{ $fontSize: number }>`
+  font-size: ${(props) => props.$fontSize}px;
+  color: #1677ff;
+  flex-shrink: 0;
+  margin-left: 4px;
+`;
+
 function stripHtmlPreservingEmojis(html: string): string {
   const div = document.createElement('div');
   div.innerHTML = html;
@@ -165,6 +172,7 @@ export function CompactPostItem({
     ? sanitizeContent(replaceCustomEmojis(escapeHtml(post.spoilerText), post.emojis))
     : sanitizeContent(stripHtmlPreservingEmojis(replaceCustomEmojis(post.content, post.emojis)));
   const hasMedia = post.mediaAttachments.length > 0;
+  const hasQuote = post.quote !== undefined;
 
   return (
     <Row $rowHeight={rowHeight} onClick={onClick}>
@@ -192,6 +200,7 @@ export function CompactPostItem({
       <BodyCell $visibility={post.visibility} $hasSpoiler={hasSpoiler}>
         <BodyText $fontSize={compactFontSize} dangerouslySetInnerHTML={{ __html: bodyHtml }} />
         {hasMedia && <MediaIcon $fontSize={compactFontSize} />}
+        {hasQuote && <QuoteIcon $fontSize={compactFontSize} />}
       </BodyCell>
     </Row>
   );

--- a/src/renderer/components/Composer.tsx
+++ b/src/renderer/components/Composer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { App, Avatar, Button, Dropdown, Input, Select, Switch, Typography } from 'antd';
 import styled from 'styled-components';
 import type { Account, PostVisibility, UploadedMedia } from '../../shared/types.ts';
@@ -7,17 +7,18 @@ const { TextArea } = Input;
 const { Text } = Typography;
 const MAX_MEDIA_ATTACHMENTS = 4;
 
-interface ComposerReplyDraft {
+export interface ComposerStatusDraft {
+  type: 'reply' | 'quote';
   serverUrl: string;
   username: string;
-  inReplyToId: string;
-  mentionAcct: string;
+  postId: string;
+  acct: string;
 }
 
 interface ComposerProps {
   accounts: Account[];
-  replyDraft: ComposerReplyDraft | null;
-  onClearReplyDraft: () => void;
+  statusDraft: ComposerStatusDraft | null;
+  onClearStatusDraft: () => void;
 }
 
 const Container = styled.div<{ $dragOver: boolean }>`
@@ -108,13 +109,17 @@ const visibilityOptions: { value: PostVisibility; label: string }[] = [
   { value: 'direct', label: 'ダイレクト' },
 ];
 
+function accountKey(account: Account): string {
+  return `${account.serverUrl}|${account.username}`;
+}
+
 export function Composer({
   accounts,
-  replyDraft,
-  onClearReplyDraft,
+  statusDraft,
+  onClearStatusDraft,
 }: ComposerProps): React.JSX.Element {
   const { message } = App.useApp();
-  const [selectedAccount, setSelectedAccount] = useState(accounts[0]);
+  const [selectedAccountKey, setSelectedAccountKey] = useState<string | null>(null);
   const [text, setText] = useState('');
   const [useContentWarning, setUseContentWarning] = useState(false);
   const [spoilerText, setSpoilerText] = useState('');
@@ -125,28 +130,21 @@ export function Composer({
   const [mediaAttachments, setMediaAttachments] = useState<UploadedMedia[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (!replyDraft) {
-      return;
-    }
-
-    const replyAccount = accounts.find(
-      (account) =>
-        account.serverUrl === replyDraft.serverUrl && account.username === replyDraft.username,
-    );
-
-    if (replyAccount) {
-      setSelectedAccount(replyAccount);
-    }
-
-    const mentionPrefix = `@${replyDraft.mentionAcct} `;
-    setText((prev) => (prev.startsWith(mentionPrefix) ? prev : `${mentionPrefix}${prev}`));
-  }, [accounts, replyDraft]);
+  const draftAccount = statusDraft
+    ? accounts.find(
+        (account) =>
+          account.serverUrl === statusDraft.serverUrl && account.username === statusDraft.username,
+      )
+    : undefined;
+  const manuallySelectedAccount = selectedAccountKey
+    ? accounts.find((account) => accountKey(account) === selectedAccountKey)
+    : undefined;
+  const selectedAccount = draftAccount ?? manuallySelectedAccount ?? accounts[0];
 
   const accountMenuItems = useMemo(
     () =>
       accounts.map((account) => ({
-        key: `${account.serverUrl}|${account.username}`,
+        key: accountKey(account),
         icon: <Avatar src={account.avatarUrl} size={24} shape="square" />,
         label: `@${account.username}@${new URL(account.serverUrl).host}`,
       })),
@@ -210,20 +208,27 @@ export function Composer({
 
     setSubmitting(true);
     try {
+      const mentionPrefix = statusDraft?.type === 'reply' ? `@${statusDraft.acct} ` : undefined;
+      const statusText =
+        mentionPrefix && !trimmedText.startsWith(mentionPrefix)
+          ? `${mentionPrefix}${trimmedText}`
+          : trimmedText;
+
       await window.api.createStatus({
         serverUrl: selectedAccount.serverUrl,
         accessToken: selectedAccount.accessToken,
-        status: trimmedText,
+        status: statusText,
         spoilerText: useContentWarning ? spoilerText.trim() : undefined,
         visibility,
-        inReplyToId: replyDraft?.inReplyToId,
+        inReplyToId: statusDraft?.type === 'reply' ? statusDraft.postId : undefined,
+        quotedStatusId: statusDraft?.type === 'quote' ? statusDraft.postId : undefined,
         mediaIds: mediaAttachments.map((media) => media.id),
       });
       setText('');
       setUseContentWarning(false);
       setSpoilerText('');
       setMediaAttachments([]);
-      onClearReplyDraft();
+      onClearStatusDraft();
       message.success('投稿しました');
     } catch (e) {
       message.error(`投稿に失敗しました: ${e instanceof Error ? e.message : String(e)}`);
@@ -246,11 +251,14 @@ export function Composer({
         void uploadFiles(Array.from(event.dataTransfer.files));
       }}
     >
-      {replyDraft && (
+      {statusDraft && (
         <ReplyBanner>
-          <Text>@{replyDraft.mentionAcct} への返信</Text>
-          <Button size="small" type="text" onClick={onClearReplyDraft}>
-            返信を解除
+          <Text>
+            @{statusDraft.acct}
+            {statusDraft.type === 'reply' ? ' への返信' : ' を引用'}
+          </Text>
+          <Button size="small" type="text" onClick={onClearStatusDraft}>
+            {statusDraft.type === 'reply' ? '返信を解除' : '引用を解除'}
           </Button>
         </ReplyBanner>
       )}
@@ -259,11 +267,9 @@ export function Composer({
           menu={{
             items: accountMenuItems,
             onClick: ({ key }) => {
-              const nextAccount = accounts.find(
-                (account) => `${account.serverUrl}|${account.username}` === key,
-              );
+              const nextAccount = accounts.find((account) => accountKey(account) === key);
               if (nextAccount) {
-                setSelectedAccount(nextAccount);
+                setSelectedAccountKey(accountKey(nextAccount));
                 setMediaAttachments([]);
               }
             },

--- a/src/renderer/components/NotificationItem.tsx
+++ b/src/renderer/components/NotificationItem.tsx
@@ -91,6 +91,29 @@ const StatusPreview = styled.div<{ $fontSize: number }>`
     width: auto;
     vertical-align: -0.1em;
   }
+
+  blockquote {
+    margin: 8px 0;
+    padding: 8px 12px;
+    border-left: 4px solid #91caff;
+    background: #f0f7ff;
+    color: #434343;
+  }
+
+  blockquote p:last-child {
+    margin-bottom: 0;
+  }
+
+  q {
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: #f0f7ff;
+    color: #434343;
+  }
+
+  .quote-inline {
+    display: none;
+  }
 `;
 
 const Timestamp = styled.span<{ $fontSize: number }>`
@@ -122,9 +145,10 @@ function formatTimestamp(isoString: string): string {
 
 function sanitizeContent(html: string): string {
   return sanitizeHtml(html, {
-    allowedTags: ['a', 'br', 'p', 'span', 'em', 'strong', 'b', 'i', 'u', 'img'],
+    allowedTags: ['a', 'br', 'p', 'span', 'em', 'strong', 'b', 'i', 'u', 'blockquote', 'q', 'img'],
     allowedAttributes: {
       a: ['href', 'rel', 'target', 'class'],
+      p: ['class'],
       span: ['class'],
       img: ['src', 'alt', 'title', 'class'],
     },

--- a/src/renderer/components/PostItem.tsx
+++ b/src/renderer/components/PostItem.tsx
@@ -6,6 +6,7 @@ import {
   BookOutlined,
   BookFilled,
   MessageOutlined,
+  LinkOutlined,
 } from '@ant-design/icons';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
@@ -19,6 +20,7 @@ interface PostItemProps {
   serverUrl: string;
   accessToken: string;
   onReply?: (post: Post) => void;
+  onQuote?: (post: Post) => void;
   onOpenAccountTimeline?: (account: Post['account']) => void;
   onCollapse?: () => void;
 }
@@ -147,6 +149,146 @@ const PostBody = styled.div<{ $fontSize: number }>`
     width: auto;
     vertical-align: -0.1em;
   }
+
+  blockquote {
+    margin: 8px 0;
+    padding: 8px 12px;
+    border-left: 4px solid #91caff;
+    background: #f0f7ff;
+    color: #434343;
+  }
+
+  blockquote p:last-child {
+    margin-bottom: 0;
+  }
+
+  q {
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: #f0f7ff;
+    color: #434343;
+  }
+
+  .quote-inline {
+    display: none;
+  }
+`;
+
+const QuotePreview = styled.div<{ $fontSize: number }>`
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid #d9d9d9;
+  border-left: 4px solid #1677ff;
+  border-radius: 6px;
+  background: #fafafa;
+  font-size: ${(props) => props.$fontSize}px;
+`;
+
+const QuoteHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  margin-bottom: 6px;
+`;
+
+const QuoteAvatar = styled.img`
+  width: 24px;
+  height: 24px;
+  border-radius: 3px;
+  flex-shrink: 0;
+`;
+
+const QuoteIdentity = styled.button`
+  display: inline-flex;
+  gap: 6px;
+  align-items: baseline;
+  min-width: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover .quote-acct,
+  &:hover .quote-name {
+    color: #1677ff;
+  }
+`;
+
+const QuoteName = styled.span`
+  color: #262626;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  .custom-emoji {
+    height: 1em;
+    width: auto;
+    vertical-align: middle;
+    margin: 0 1px;
+  }
+`;
+
+const QuoteAcct = styled.span`
+  color: #8c8c8c;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const QuoteBody = styled.div`
+  color: #434343;
+  line-height: 1.5;
+  word-break: break-word;
+
+  p {
+    margin: 0 0 4px;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  a {
+    color: #1677ff;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  img.custom-emoji {
+    height: 1em;
+    width: auto;
+    vertical-align: -0.1em;
+  }
+
+  blockquote {
+    margin: 6px 0;
+    padding: 6px 10px;
+    border-left: 3px solid #91caff;
+    background: #f0f7ff;
+  }
+
+  q {
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: #f0f7ff;
+  }
+
+  .quote-inline {
+    display: none;
+  }
+`;
+
+const QuotePlaceholder = styled.div`
+  color: #8c8c8c;
 `;
 
 const ContentWarning = styled.button<{ $fontSize: number }>`
@@ -227,6 +369,7 @@ function sanitizeContent(html: string): string {
       'code',
       'pre',
       'blockquote',
+      'q',
       'ul',
       'ol',
       'li',
@@ -234,6 +377,7 @@ function sanitizeContent(html: string): string {
     ],
     allowedAttributes: {
       a: ['href', 'rel', 'target', 'class'],
+      p: ['class'],
       span: ['class'],
       img: ['src', 'alt', 'title', 'class'],
     },
@@ -248,11 +392,79 @@ function escapeHtml(text: string): string {
     .replace(/"/g, '&quot;');
 }
 
+function quoteStateLabel(state: NonNullable<Post['quote']>['state']): string {
+  switch (state) {
+    case 'pending':
+      return '引用は承認待ちです';
+    case 'rejected':
+    case 'revoked':
+      return '引用は表示できません';
+    case 'deleted':
+      return '引用元の投稿は削除されています';
+    case 'unauthorized':
+      return '引用元の投稿を表示する権限がありません';
+    case 'blocked_account':
+    case 'blocked_domain':
+    case 'muted_account':
+      return '引用元の投稿は表示されません';
+    case 'accepted':
+      return '引用元の投稿を読み込めません';
+  }
+}
+
+function QuoteCard({
+  quote,
+  fontSize,
+  onOpenAccountTimeline,
+}: {
+  quote: NonNullable<Post['quote']>;
+  fontSize: number;
+  onOpenAccountTimeline?: (account: Post['account']) => void;
+}): React.JSX.Element {
+  const quotedPost = quote.quotedPost;
+
+  if (!quotedPost) {
+    return (
+      <QuotePreview $fontSize={fontSize}>
+        <QuotePlaceholder>{quoteStateLabel(quote.state)}</QuotePlaceholder>
+      </QuotePreview>
+    );
+  }
+
+  return (
+    <QuotePreview $fontSize={fontSize}>
+      <QuoteHeader>
+        <QuoteAvatar src={quotedPost.account.avatarUrl} alt={quotedPost.account.acct} />
+        <QuoteIdentity type="button" onClick={() => onOpenAccountTimeline?.(quotedPost.account)}>
+          <QuoteName
+            className="quote-name"
+            dangerouslySetInnerHTML={{
+              __html: sanitizeContent(
+                replaceCustomEmojis(
+                  escapeHtml(quotedPost.account.displayName),
+                  quotedPost.account.emojis,
+                ),
+              ),
+            }}
+          />
+          <QuoteAcct className="quote-acct">@{quotedPost.account.acct}</QuoteAcct>
+        </QuoteIdentity>
+      </QuoteHeader>
+      <QuoteBody
+        dangerouslySetInnerHTML={{
+          __html: sanitizeContent(replaceCustomEmojis(quotedPost.content, quotedPost.emojis)),
+        }}
+      />
+    </QuotePreview>
+  );
+}
+
 export function PostItem({
   post,
   serverUrl,
   accessToken,
   onReply,
+  onQuote,
   onOpenAccountTimeline,
   onCollapse,
 }: PostItemProps): React.JSX.Element {
@@ -391,6 +603,13 @@ export function PostItem({
         {hasMediaAttachments && !shouldHideMedia && (
           <MediaGallery attachments={post.mediaAttachments} />
         )}
+        {post.quote && !shouldHideContent && (
+          <QuoteCard
+            quote={post.quote}
+            fontSize={smallFontSize}
+            onOpenAccountTimeline={onOpenAccountTimeline}
+          />
+        )}
         <FooterLine>
           {post.url ? (
             <Timestamp $fontSize={smallFontSize} href={post.url} onClick={handleTimestampClick}>
@@ -428,6 +647,15 @@ export function PostItem({
             title="メンションで返信"
           >
             <MessageOutlined />
+          </ActionButton>
+          <ActionButton
+            $active={false}
+            $activeColor="#1677ff"
+            $fontSize={smallFontSize}
+            onClick={() => onQuote?.(post)}
+            title="引用"
+          >
+            <LinkOutlined />
           </ActionButton>
           <ActionButton
             $active={bookmarked}

--- a/src/renderer/pages/TimelinePage.tsx
+++ b/src/renderer/pages/TimelinePage.tsx
@@ -35,20 +35,13 @@ import type {
 } from '../../shared/types.ts';
 import { PostItem } from '../components/PostItem.tsx';
 import { NotificationItem } from '../components/NotificationItem.tsx';
-import { Composer } from '../components/Composer.tsx';
+import { Composer, type ComposerStatusDraft } from '../components/Composer.tsx';
 import { CompactPostItem } from '../components/CompactPostItem.tsx';
 import { PaneContainer } from '../components/PaneContainer.tsx';
 import { useSettings } from '../hooks/useSettings.ts';
 import { replaceCustomEmojis } from '../components/customEmojis.ts';
 
 const { Text } = Typography;
-
-interface ComposerReplyDraft {
-  serverUrl: string;
-  username: string;
-  inReplyToId: string;
-  mentionAcct: string;
-}
 
 interface AccountTimelineTarget {
   id: string;
@@ -482,11 +475,13 @@ function TimelineTabContent({
   tab,
   accounts,
   onReply,
+  onQuote,
   onOpenAccountTimeline,
 }: {
   tab: TabDefinition;
   accounts: Account[];
   onReply: (tab: TabDefinition, post: Post) => void;
+  onQuote: (tab: TabDefinition, post: Post) => void;
   onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }): React.JSX.Element {
   const { message } = App.useApp();
@@ -707,6 +702,7 @@ function TimelineTabContent({
             serverUrl={account.serverUrl}
             accessToken={account.accessToken}
             onReply={(targetPost) => onReply(tab, targetPost)}
+            onQuote={(targetPost) => onQuote(tab, targetPost)}
             onOpenAccountTimeline={(targetAccount) => onOpenAccountTimeline(tab, targetAccount)}
             onCollapse={settings.disableCompactDisplay ? undefined : () => setExpandedPostId(null)}
           />
@@ -914,11 +910,13 @@ function TabContent({
   tab,
   accounts,
   onReply,
+  onQuote,
   onOpenAccountTimeline,
 }: {
   tab: TabDefinition;
   accounts: Account[];
   onReply: (tab: TabDefinition, post: Post) => void;
+  onQuote: (tab: TabDefinition, post: Post) => void;
   onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }): React.JSX.Element {
   if (tab.timelineType === 'notifications') {
@@ -935,6 +933,7 @@ function TabContent({
       tab={tab}
       accounts={accounts}
       onReply={onReply}
+      onQuote={onQuote}
       onOpenAccountTimeline={onOpenAccountTimeline}
     />
   );
@@ -952,6 +951,7 @@ interface PaneProps {
   onMoveTab: (tabId: string, fromPaneId: string, direction: 'left' | 'right') => void;
   onRenameTab: (tabId: string, name: string) => void;
   onReply: (tab: TabDefinition, post: Post) => void;
+  onQuote: (tab: TabDefinition, post: Post) => void;
   onOpenAccountTimeline: (tab: TabDefinition, target: AccountTimelineTarget) => void;
 }
 
@@ -976,6 +976,7 @@ function Pane({
   onMoveTab,
   onRenameTab,
   onReply,
+  onQuote,
   onOpenAccountTimeline,
 }: PaneProps): React.JSX.Element {
   const [connectionStatuses, setConnectionStatuses] = useState<
@@ -1054,6 +1055,7 @@ function Pane({
           tab={tab}
           accounts={accounts}
           onReply={onReply}
+          onQuote={onQuote}
           onOpenAccountTimeline={onOpenAccountTimeline}
         />
       ),
@@ -1124,7 +1126,7 @@ export function TimelinePage({
   const [tabs, setTabs] = useState<TabDefinition[]>([]);
   const [panes, setPanes] = useState<PaneDefinition[]>([]);
   const [loaded, setLoaded] = useState(false);
-  const [replyDraft, setReplyDraft] = useState<ComposerReplyDraft | null>(null);
+  const [statusDraft, setStatusDraft] = useState<ComposerStatusDraft | null>(null);
 
   // Modal state
   const [modalOpen, setModalOpen] = useState(false);
@@ -1370,13 +1372,24 @@ export function TimelinePage({
   }));
 
   const handleReply = useCallback((tab: TabDefinition, post: Post): void => {
-    setReplyDraft({
+    setStatusDraft({
+      type: 'reply',
       serverUrl: tab.accountServerUrl,
       username: tab.accountUsername,
-      inReplyToId: post.id,
-      mentionAcct: post.account.acct,
+      postId: post.id,
+      acct: post.account.acct,
     });
   }, []);
+
+  const handleQuote = (tab: TabDefinition, post: Post): void => {
+    setStatusDraft({
+      type: 'quote',
+      serverUrl: tab.accountServerUrl,
+      username: tab.accountUsername,
+      postId: post.id,
+      acct: post.account.acct,
+    });
+  };
 
   const handleOpenAccountTimeline = useCallback(
     (sourceTab: TabDefinition, target: AccountTimelineTarget): void => {
@@ -1413,9 +1426,9 @@ export function TimelinePage({
     [panes, persistLayout],
   );
 
-  const handleClearReplyDraft = useCallback((): void => {
-    setReplyDraft(null);
-  }, []);
+  const handleClearStatusDraft = (): void => {
+    setStatusDraft(null);
+  };
 
   const widthRatios = panes.map((p) => p.widthRatio);
 
@@ -1425,8 +1438,8 @@ export function TimelinePage({
         <div style={{ flex: 1, minWidth: 0 }}>
           <Composer
             accounts={accounts}
-            replyDraft={replyDraft}
-            onClearReplyDraft={handleClearReplyDraft}
+            statusDraft={statusDraft}
+            onClearStatusDraft={handleClearStatusDraft}
           />
         </div>
         <Flex vertical align="center" style={{ padding: '8px 4px 0 0', flexShrink: 0 }}>
@@ -1466,6 +1479,7 @@ export function TimelinePage({
             onMoveTab={handleMoveTab}
             onRenameTab={handleRenameTab}
             onReply={handleReply}
+            onQuote={handleQuote}
             onOpenAccountTimeline={handleOpenAccountTimeline}
           />
         ))}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -153,6 +153,7 @@ export interface StatusCreateParams {
   spoilerText?: string;
   visibility: PostVisibility;
   inReplyToId?: string;
+  quotedStatusId?: string;
   mediaIds?: string[];
 }
 
@@ -214,6 +215,42 @@ export interface PostCustomEmoji {
   staticUrl: string;
 }
 
+export type PostQuoteState =
+  | 'pending'
+  | 'accepted'
+  | 'rejected'
+  | 'revoked'
+  | 'deleted'
+  | 'unauthorized'
+  | 'blocked_account'
+  | 'blocked_domain'
+  | 'muted_account';
+
+export interface QuotedPost {
+  id: string;
+  content: string;
+  spoilerText: string;
+  sensitive: boolean;
+  createdAt: string;
+  url: string | null;
+  account: {
+    id: string;
+    acct: string;
+    displayName: string;
+    avatarUrl: string;
+    emojis: PostCustomEmoji[];
+  };
+  mediaAttachments: PostMediaAttachment[];
+  visibility: PostVisibility;
+  emojis: PostCustomEmoji[];
+}
+
+export interface PostQuote {
+  state: PostQuoteState;
+  quotedStatusId?: string;
+  quotedPost?: QuotedPost;
+}
+
 /** A post (status) to render in the timeline */
 export interface Post {
   id: string;
@@ -241,6 +278,7 @@ export interface Post {
     displayName: string;
     avatarUrl: string;
   };
+  quote?: PostQuote;
 }
 
 /** Parameters for fetching a timeline */


### PR DESCRIPTION
## Summary
- Convert Mastodon quote data into the shared Post model and render quoted post previews in timeline items
- Add a quote action that creates posts with quotedStatusId
- Improve blockquote/q rendering and hide Mastodon quote-inline fallback text

## Tests
- bun run typecheck
- bun run lint
- bun run build
- bunx react-doctor@latest . --verbose --diff (2 sanitized HTML warnings remain in quote preview rendering)

Closes #62